### PR TITLE
feat: add diff position calculation for GitHub inline comments

### DIFF
--- a/internal/adapter/github/doc.go
+++ b/internal/adapter/github/doc.go
@@ -1,0 +1,11 @@
+// Package github provides types and utilities for GitHub PR review integration.
+//
+// This adapter layer handles GitHub-specific concerns without polluting the
+// domain layer. Key types include:
+//
+//   - PositionedFinding: Wraps domain.Finding with GitHub diff position
+//   - MapFindings: Enriches findings with diff positions for inline comments
+//
+// The design keeps the domain layer pure and platform-agnostic, enabling
+// future support for GitLab, Bitbucket, or other platforms.
+package github

--- a/internal/adapter/github/mapper.go
+++ b/internal/adapter/github/mapper.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"github.com/bkyoung/code-reviewer/internal/diff"
+	"github.com/bkyoung/code-reviewer/internal/domain"
+)
+
+// MapFindings enriches domain findings with GitHub diff positions.
+// Findings are mapped to their corresponding position in the unified diff,
+// which is required for creating inline PR review comments.
+//
+// If a finding's line is not in the diff (e.g., unchanged code, deleted line,
+// or line outside diff hunks), DiffPosition will be nil.
+//
+// This function is pure and does not modify the input findings.
+func MapFindings(findings []domain.Finding, d domain.Diff) []PositionedFinding {
+	if len(findings) == 0 {
+		return []PositionedFinding{}
+	}
+
+	// Build a map of file path -> parsed diff for O(1) lookup
+	parsedDiffs := make(map[string]diff.ParsedDiff, len(d.Files))
+	for _, fileDiff := range d.Files {
+		parsed, err := diff.Parse(fileDiff.Patch)
+		if err != nil {
+			// Skip files with unparseable diffs
+			continue
+		}
+		parsedDiffs[fileDiff.Path] = parsed
+	}
+
+	// Map each finding to its positioned version
+	result := make([]PositionedFinding, len(findings))
+	for i, finding := range findings {
+		pf := PositionedFinding{
+			Finding: finding,
+		}
+
+		// Look up the diff for this finding's file
+		if parsed, ok := parsedDiffs[finding.File]; ok {
+			// Get position for the finding's start line
+			pf.DiffPosition = parsed.FindPosition(finding.LineStart)
+		}
+
+		result[i] = pf
+	}
+
+	return result
+}

--- a/internal/adapter/github/mapper_test.go
+++ b/internal/adapter/github/mapper_test.go
@@ -1,0 +1,295 @@
+package github_test
+
+import (
+	"testing"
+
+	"github.com/bkyoung/code-reviewer/internal/adapter/github"
+	"github.com/bkyoung/code-reviewer/internal/diff"
+	"github.com/bkyoung/code-reviewer/internal/domain"
+)
+
+func TestMapFindings_SingleFile(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{
+				Path:   "main.go",
+				Status: domain.FileStatusModified,
+				Patch: `@@ -10,3 +10,4 @@ func example() {
+ context line 10
++added line 11
+ context line 12
+`,
+			},
+		},
+	}
+
+	findings := []domain.Finding{
+		{
+			ID:        "f1",
+			File:      "main.go",
+			LineStart: 11,
+			LineEnd:   11,
+			Severity:  "medium",
+		},
+	}
+
+	result := github.MapFindings(findings, diff)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	if result[0].Finding.ID != "f1" {
+		t.Errorf("expected finding ID 'f1', got '%s'", result[0].Finding.ID)
+	}
+
+	if result[0].DiffPosition == nil {
+		t.Fatal("expected DiffPosition to be set")
+	}
+
+	if *result[0].DiffPosition != 2 {
+		t.Errorf("expected DiffPosition=2, got %d", *result[0].DiffPosition)
+	}
+}
+
+func TestMapFindings_MultipleFiles(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{
+				Path:   "file1.go",
+				Status: domain.FileStatusModified,
+				Patch: `@@ -1,2 +1,3 @@
+ line 1
++added line 2
+`,
+			},
+			{
+				Path:   "file2.go",
+				Status: domain.FileStatusModified,
+				Patch: `@@ -5,2 +5,3 @@
+ line 5
++added line 6
+`,
+			},
+		},
+	}
+
+	findings := []domain.Finding{
+		{ID: "f1", File: "file1.go", LineStart: 2},
+		{ID: "f2", File: "file2.go", LineStart: 6},
+	}
+
+	result := github.MapFindings(findings, diff)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result))
+	}
+
+	// file1.go: line 2 is at position 2
+	if result[0].DiffPosition == nil || *result[0].DiffPosition != 2 {
+		t.Errorf("f1: expected position 2, got %v", result[0].DiffPosition)
+	}
+
+	// file2.go: line 6 is at position 2 (within that file's diff)
+	if result[1].DiffPosition == nil || *result[1].DiffPosition != 2 {
+		t.Errorf("f2: expected position 2, got %v", result[1].DiffPosition)
+	}
+}
+
+func TestMapFindings_FileNotInDiff(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{
+				Path:   "other.go",
+				Status: domain.FileStatusModified,
+				Patch: `@@ -1,2 +1,3 @@
+ context
++added
+`,
+			},
+		},
+	}
+
+	findings := []domain.Finding{
+		{ID: "f1", File: "missing.go", LineStart: 10},
+	}
+
+	result := github.MapFindings(findings, diff)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	if result[0].DiffPosition != nil {
+		t.Errorf("expected nil DiffPosition for missing file, got %d", *result[0].DiffPosition)
+	}
+}
+
+func TestMapFindings_LineNotInDiff(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{
+				Path:   "main.go",
+				Status: domain.FileStatusModified,
+				Patch: `@@ -10,2 +10,3 @@
+ context line 10
++added line 11
+`,
+			},
+		},
+	}
+
+	findings := []domain.Finding{
+		{ID: "f1", File: "main.go", LineStart: 50}, // Line not in diff
+	}
+
+	result := github.MapFindings(findings, diff)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	if result[0].DiffPosition != nil {
+		t.Errorf("expected nil DiffPosition for line not in diff, got %d", *result[0].DiffPosition)
+	}
+}
+
+func TestMapFindings_EmptyFindings(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{Path: "main.go", Patch: "@@ -1 +1 @@\n+line"},
+		},
+	}
+
+	result := github.MapFindings([]domain.Finding{}, diff)
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 results, got %d", len(result))
+	}
+}
+
+func TestMapFindings_EmptyDiff(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{},
+	}
+
+	findings := []domain.Finding{
+		{ID: "f1", File: "main.go", LineStart: 10},
+	}
+
+	result := github.MapFindings(findings, diff)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	if result[0].DiffPosition != nil {
+		t.Errorf("expected nil DiffPosition for empty diff, got %d", *result[0].DiffPosition)
+	}
+}
+
+func TestMapFindings_PreservesAllFindingFields(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{
+				Path:  "main.go",
+				Patch: "@@ -1,1 +1,2 @@\n context\n+added line 2",
+			},
+		},
+	}
+
+	original := domain.Finding{
+		ID:          "abc123",
+		File:        "main.go",
+		LineStart:   2,
+		LineEnd:     5,
+		Severity:    "high",
+		Category:    "security",
+		Description: "SQL injection vulnerability",
+		Suggestion:  "Use parameterized queries",
+		Evidence:    true,
+	}
+
+	result := github.MapFindings([]domain.Finding{original}, diff)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	f := result[0].Finding
+	if f.ID != original.ID {
+		t.Errorf("ID mismatch: got %s, want %s", f.ID, original.ID)
+	}
+	if f.File != original.File {
+		t.Errorf("File mismatch: got %s, want %s", f.File, original.File)
+	}
+	if f.LineStart != original.LineStart {
+		t.Errorf("LineStart mismatch: got %d, want %d", f.LineStart, original.LineStart)
+	}
+	if f.LineEnd != original.LineEnd {
+		t.Errorf("LineEnd mismatch: got %d, want %d", f.LineEnd, original.LineEnd)
+	}
+	if f.Severity != original.Severity {
+		t.Errorf("Severity mismatch: got %s, want %s", f.Severity, original.Severity)
+	}
+	if f.Category != original.Category {
+		t.Errorf("Category mismatch: got %s, want %s", f.Category, original.Category)
+	}
+	if f.Description != original.Description {
+		t.Errorf("Description mismatch")
+	}
+	if f.Suggestion != original.Suggestion {
+		t.Errorf("Suggestion mismatch")
+	}
+	if f.Evidence != original.Evidence {
+		t.Errorf("Evidence mismatch")
+	}
+}
+
+func TestMapFindings_MalformedPatch(t *testing.T) {
+	diff := domain.Diff{
+		Files: []domain.FileDiff{
+			{
+				Path:  "main.go",
+				Patch: "this is not a valid diff",
+			},
+		},
+	}
+
+	findings := []domain.Finding{
+		{ID: "f1", File: "main.go", LineStart: 10},
+	}
+
+	// Should not panic, should return nil position
+	result := github.MapFindings(findings, diff)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	if result[0].DiffPosition != nil {
+		t.Errorf("expected nil DiffPosition for malformed patch")
+	}
+}
+
+func TestPositionedFinding_InDiff(t *testing.T) {
+	pf := github.PositionedFinding{
+		Finding:      domain.Finding{ID: "test"},
+		DiffPosition: diff.IntPtr(5),
+	}
+
+	if !pf.InDiff() {
+		t.Error("expected InDiff() to return true when DiffPosition is set")
+	}
+}
+
+func TestPositionedFinding_InDiff_False(t *testing.T) {
+	pf := github.PositionedFinding{
+		Finding:      domain.Finding{ID: "test"},
+		DiffPosition: nil,
+	}
+
+	if pf.InDiff() {
+		t.Error("expected InDiff() to return false when DiffPosition is nil")
+	}
+}

--- a/internal/adapter/github/types.go
+++ b/internal/adapter/github/types.go
@@ -1,0 +1,23 @@
+package github
+
+import "github.com/bkyoung/code-reviewer/internal/domain"
+
+// PositionedFinding wraps a domain.Finding with GitHub-specific diff position.
+// This type lives in the adapter layer to keep the domain layer pure and
+// platform-agnostic.
+type PositionedFinding struct {
+	// Finding is the original domain finding with all review details.
+	Finding domain.Finding
+
+	// DiffPosition is the line position within the GitHub diff.
+	// This is 1-indexed from the first @@ hunk header.
+	// nil indicates the finding's line is not in the diff and cannot
+	// receive an inline comment (should be included in summary only).
+	DiffPosition *int
+}
+
+// InDiff returns true if the finding can receive an inline PR comment.
+// Returns false if the finding's line is not part of the diff.
+func (pf PositionedFinding) InDiff() bool {
+	return pf.DiffPosition != nil
+}

--- a/internal/diff/doc.go
+++ b/internal/diff/doc.go
@@ -1,0 +1,10 @@
+// Package diff provides utilities for parsing unified diff format
+// and mapping file line numbers to diff positions for GitHub PR review comments.
+//
+// The primary use case is to convert absolute file line numbers (from LLM
+// findings) to GitHub's diff position format, which is required for creating
+// inline PR review comments.
+//
+// Position in GitHub's API is 1-indexed from the first @@ hunk header,
+// counting all lines in the diff (context, additions, and deletions).
+package diff

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -1,0 +1,210 @@
+package diff
+
+import (
+	"strconv"
+	"strings"
+)
+
+// LineType represents the type of a line in a diff.
+type LineType int
+
+const (
+	// LineContext represents an unchanged context line (starts with ' ').
+	LineContext LineType = iota
+	// LineAddition represents an added line (starts with '+').
+	LineAddition
+	// LineDeletion represents a deleted line (starts with '-').
+	LineDeletion
+)
+
+// Line represents a single line in a diff hunk.
+type Line struct {
+	Type     LineType // The type of change
+	Content  string   // The line content (without the prefix)
+	NewLine  *int     // Line number in new file (nil for deletions)
+	Position int      // Position in diff (1-indexed from first @@)
+}
+
+// Hunk represents a single @@ hunk in a unified diff.
+type Hunk struct {
+	OldStart int    // Starting line in old file
+	OldLines int    // Number of lines from old file
+	NewStart int    // Starting line in new file
+	NewLines int    // Number of lines in new file
+	Lines    []Line // The lines in this hunk
+}
+
+// ParsedDiff represents a parsed unified diff for a single file.
+type ParsedDiff struct {
+	Hunks []Hunk
+}
+
+// Parse parses a unified diff string into a ParsedDiff.
+// It handles standard git diff output including file headers.
+func Parse(patch string) (ParsedDiff, error) {
+	if patch == "" {
+		return ParsedDiff{}, nil
+	}
+
+	lines := strings.Split(patch, "\n")
+	result := ParsedDiff{}
+
+	var currentHunk *Hunk
+	position := 0
+	currentNewLine := 0
+
+	for _, line := range lines {
+		// Skip empty lines at end
+		if line == "" {
+			continue
+		}
+
+		// Skip file headers (diff --git, index, ---, +++)
+		if strings.HasPrefix(line, "diff --git") ||
+			strings.HasPrefix(line, "index ") ||
+			strings.HasPrefix(line, "--- ") ||
+			strings.HasPrefix(line, "+++ ") {
+			continue
+		}
+
+		// Skip "\ No newline at end of file" markers
+		if strings.HasPrefix(line, "\\ ") {
+			continue
+		}
+
+		// Parse hunk header
+		if strings.HasPrefix(line, "@@") {
+			// Save previous hunk if exists
+			if currentHunk != nil {
+				result.Hunks = append(result.Hunks, *currentHunk)
+			}
+
+			hunk, err := parseHunkHeader(line)
+			if err != nil {
+				// Skip malformed headers
+				continue
+			}
+
+			currentHunk = &hunk
+			currentNewLine = hunk.NewStart
+			continue
+		}
+
+		// Skip if not in a hunk yet
+		if currentHunk == nil {
+			continue
+		}
+
+		// Parse diff line
+		position++
+		diffLine := Line{
+			Position: position,
+		}
+
+		if len(line) > 0 {
+			switch line[0] {
+			case '+':
+				diffLine.Type = LineAddition
+				diffLine.Content = line[1:]
+				diffLine.NewLine = IntPtr(currentNewLine)
+				currentNewLine++
+			case '-':
+				diffLine.Type = LineDeletion
+				diffLine.Content = line[1:]
+				// Deletions don't have new-side line numbers
+				diffLine.NewLine = nil
+			case ' ':
+				diffLine.Type = LineContext
+				diffLine.Content = line[1:]
+				diffLine.NewLine = IntPtr(currentNewLine)
+				currentNewLine++
+			default:
+				// Treat unknown as context (handles edge cases)
+				diffLine.Type = LineContext
+				diffLine.Content = line
+				diffLine.NewLine = IntPtr(currentNewLine)
+				currentNewLine++
+			}
+		}
+
+		currentHunk.Lines = append(currentHunk.Lines, diffLine)
+	}
+
+	// Don't forget the last hunk
+	if currentHunk != nil {
+		result.Hunks = append(result.Hunks, *currentHunk)
+	}
+
+	return result, nil
+}
+
+// FindPosition returns the diff position for a given new-side line number.
+// Returns nil if the line is not in the diff (context-only file regions,
+// deleted lines, or lines outside the diff).
+// Position is 1-indexed from the first @@ hunk header.
+func (pd ParsedDiff) FindPosition(newLineNumber int) *int {
+	if newLineNumber <= 0 {
+		return nil
+	}
+
+	for _, hunk := range pd.Hunks {
+		for _, line := range hunk.Lines {
+			if line.NewLine != nil && *line.NewLine == newLineNumber {
+				return IntPtr(line.Position)
+			}
+		}
+	}
+
+	return nil
+}
+
+// parseHunkHeader parses a hunk header line like "@@ -10,7 +10,8 @@ optional context".
+func parseHunkHeader(line string) (Hunk, error) {
+	hunk := Hunk{}
+
+	// Find the @@ markers
+	parts := strings.Split(line, "@@")
+	if len(parts) < 2 {
+		return hunk, nil
+	}
+
+	// Parse the range info between @@ markers
+	rangeInfo := strings.TrimSpace(parts[1])
+	rangeParts := strings.Fields(rangeInfo)
+
+	for _, part := range rangeParts {
+		if strings.HasPrefix(part, "-") {
+			// Old file range: -start,count or -start
+			old := strings.TrimPrefix(part, "-")
+			oldStart, oldLines := parseRange(old)
+			hunk.OldStart = oldStart
+			hunk.OldLines = oldLines
+		} else if strings.HasPrefix(part, "+") {
+			// New file range: +start,count or +start
+			new := strings.TrimPrefix(part, "+")
+			newStart, newLines := parseRange(new)
+			hunk.NewStart = newStart
+			hunk.NewLines = newLines
+		}
+	}
+
+	return hunk, nil
+}
+
+// parseRange parses "start,count" or "start" format.
+func parseRange(s string) (start, count int) {
+	if idx := strings.Index(s, ","); idx >= 0 {
+		start, _ = strconv.Atoi(s[:idx])
+		count, _ = strconv.Atoi(s[idx+1:])
+	} else {
+		start, _ = strconv.Atoi(s)
+		count = 1
+	}
+	return
+}
+
+// IntPtr returns a pointer to the given int value.
+// Exported for use in tests across packages.
+func IntPtr(n int) *int {
+	return &n
+}

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -1,0 +1,356 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/bkyoung/code-reviewer/internal/diff"
+)
+
+// equalIntPtr compares two *int values for equality (test helper).
+func equalIntPtr(a, b *int) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func TestParse_SingleHunk(t *testing.T) {
+	patch := `@@ -10,3 +10,4 @@ func example() {
+ context line
++added line
+ another context
++second addition
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(parsed.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(parsed.Hunks))
+	}
+
+	hunk := parsed.Hunks[0]
+	if hunk.NewStart != 10 {
+		t.Errorf("expected NewStart=10, got %d", hunk.NewStart)
+	}
+
+	// Should have 4 lines: context, addition, context, addition
+	if len(hunk.Lines) != 4 {
+		t.Errorf("expected 4 lines, got %d", len(hunk.Lines))
+	}
+}
+
+func TestParse_MultipleHunks(t *testing.T) {
+	patch := `@@ -10,2 +10,3 @@ func first() {
+ context
++added
+@@ -20,2 +21,3 @@ func second() {
+ context
++added
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(parsed.Hunks) != 2 {
+		t.Fatalf("expected 2 hunks, got %d", len(parsed.Hunks))
+	}
+
+	if parsed.Hunks[0].NewStart != 10 {
+		t.Errorf("hunk 0: expected NewStart=10, got %d", parsed.Hunks[0].NewStart)
+	}
+	if parsed.Hunks[1].NewStart != 21 {
+		t.Errorf("hunk 1: expected NewStart=21, got %d", parsed.Hunks[1].NewStart)
+	}
+}
+
+func TestParse_AdditionsOnly(t *testing.T) {
+	// New file - all additions
+	patch := `@@ -0,0 +1,3 @@
++line one
++line two
++line three
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(parsed.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(parsed.Hunks))
+	}
+
+	hunk := parsed.Hunks[0]
+	if len(hunk.Lines) != 3 {
+		t.Errorf("expected 3 lines, got %d", len(hunk.Lines))
+	}
+
+	for i, line := range hunk.Lines {
+		if line.Type != diff.LineAddition {
+			t.Errorf("line %d: expected Addition, got %v", i, line.Type)
+		}
+	}
+}
+
+func TestParse_DeletionsOnly(t *testing.T) {
+	// Deleted file - all deletions
+	patch := `@@ -1,3 +0,0 @@
+-line one
+-line two
+-line three
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(parsed.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(parsed.Hunks))
+	}
+
+	hunk := parsed.Hunks[0]
+	for i, line := range hunk.Lines {
+		if line.Type != diff.LineDeletion {
+			t.Errorf("line %d: expected Deletion, got %v", i, line.Type)
+		}
+		if line.NewLine != nil {
+			t.Errorf("line %d: deletion should have nil NewLine", i)
+		}
+	}
+}
+
+func TestParse_MixedChanges(t *testing.T) {
+	patch := `@@ -5,4 +5,4 @@ package main
+ import "fmt"
+-func old() {}
++func new() {}
+ func main() {}
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	hunk := parsed.Hunks[0]
+	// context, deletion, addition, context = 4 lines
+	if len(hunk.Lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d", len(hunk.Lines))
+	}
+
+	expected := []diff.LineType{
+		diff.LineContext,
+		diff.LineDeletion,
+		diff.LineAddition,
+		diff.LineContext,
+	}
+
+	for i, line := range hunk.Lines {
+		if line.Type != expected[i] {
+			t.Errorf("line %d: expected %v, got %v", i, expected[i], line.Type)
+		}
+	}
+}
+
+func TestParse_EmptyPatch(t *testing.T) {
+	parsed, err := diff.Parse("")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(parsed.Hunks) != 0 {
+		t.Errorf("expected 0 hunks for empty patch, got %d", len(parsed.Hunks))
+	}
+}
+
+func TestParsedDiff_FindPosition_InDiff(t *testing.T) {
+	patch := `@@ -10,3 +10,4 @@ func example() {
+ context line 10
++added line 11
+ context line 12
++added line 13
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		lineNumber int
+		wantPos    *int
+	}{
+		{"context line 10", 10, diff.IntPtr(1)},
+		{"added line 11", 11, diff.IntPtr(2)},
+		{"context line 12", 12, diff.IntPtr(3)},
+		{"added line 13", 13, diff.IntPtr(4)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsed.FindPosition(tt.lineNumber)
+			if !equalIntPtr(got, tt.wantPos) {
+				t.Errorf("FindPosition(%d) = %v, want %v", tt.lineNumber, got, tt.wantPos)
+			}
+		})
+	}
+}
+
+func TestParsedDiff_FindPosition_NotInDiff(t *testing.T) {
+	patch := `@@ -10,2 +10,3 @@ func example() {
+ context line 10
++added line 11
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		lineNumber int
+	}{
+		{"line before diff", 5},
+		{"line after diff", 20},
+		{"line 0 (invalid)", 0},
+		{"negative line", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsed.FindPosition(tt.lineNumber)
+			if got != nil {
+				t.Errorf("FindPosition(%d) = %v, want nil", tt.lineNumber, *got)
+			}
+		})
+	}
+}
+
+func TestParsedDiff_FindPosition_DeletedLine(t *testing.T) {
+	// Deletions don't have new-side line numbers, so can't be found
+	patch := `@@ -10,3 +10,2 @@ func example() {
+ context line 10
+-deleted line (was 11)
+ context line 11 (was 12)
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Line 10 should be at position 1
+	pos := parsed.FindPosition(10)
+	if !equalIntPtr(pos, diff.IntPtr(1)) {
+		t.Errorf("FindPosition(10) = %v, want 1", pos)
+	}
+
+	// Line 11 (the new context line) should be at position 3
+	// Position 2 is the deletion
+	pos = parsed.FindPosition(11)
+	if !equalIntPtr(pos, diff.IntPtr(3)) {
+		t.Errorf("FindPosition(11) = %v, want 3", pos)
+	}
+}
+
+func TestParsedDiff_FindPosition_MultipleHunks(t *testing.T) {
+	patch := `@@ -10,2 +10,3 @@ func first() {
+ context 10
++added 11
+@@ -20,2 +21,3 @@ func second() {
+ context 21
++added 22
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	tests := []struct {
+		lineNumber int
+		wantPos    *int
+	}{
+		{10, diff.IntPtr(1)}, // First hunk, position 1
+		{11, diff.IntPtr(2)}, // First hunk, position 2
+		{21, diff.IntPtr(3)}, // Second hunk, position 3 (continues from first)
+		{22, diff.IntPtr(4)}, // Second hunk, position 4
+		{15, nil},            // Between hunks - not in diff
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := parsed.FindPosition(tt.lineNumber)
+			if !equalIntPtr(got, tt.wantPos) {
+				t.Errorf("FindPosition(%d) = %v, want %v", tt.lineNumber, got, tt.wantPos)
+			}
+		})
+	}
+}
+
+func TestParse_NoNewlineAtEOF(t *testing.T) {
+	patch := `@@ -1,2 +1,2 @@
+ line one
+-line two
+\ No newline at end of file
++line two modified
+\ No newline at end of file
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Should have 1 hunk with lines (ignoring the "\ No newline" markers)
+	if len(parsed.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(parsed.Hunks))
+	}
+
+	// The "\ No newline" lines should be skipped
+	hunk := parsed.Hunks[0]
+	for _, line := range hunk.Lines {
+		if line.Type != diff.LineContext && line.Type != diff.LineAddition && line.Type != diff.LineDeletion {
+			t.Errorf("unexpected line type: %v", line.Type)
+		}
+	}
+}
+
+func TestParse_WithFileHeaders(t *testing.T) {
+	// Real diff with git headers
+	patch := `diff --git a/file.go b/file.go
+index 1234567..abcdefg 100644
+--- a/file.go
++++ b/file.go
+@@ -10,3 +10,4 @@ func example() {
+ context
++added
+ more context
+`
+
+	parsed, err := diff.Parse(patch)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if len(parsed.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(parsed.Hunks))
+	}
+
+	// Position should start from @@ line, not file headers
+	pos := parsed.FindPosition(10)
+	if !equalIntPtr(pos, diff.IntPtr(1)) {
+		t.Errorf("FindPosition(10) = %v, want 1", pos)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements Issue #9: Parse unified diff format and map file line numbers to GitHub diff positions
- Enables future inline PR review comments by providing the `position` parameter GitHub's API requires
- Clean architecture design keeps domain layer pure (GitHub concepts in adapter layer)

## Changes

### New Packages

| Package | Purpose |
|---------|---------|
| `internal/diff` | Pure unified diff parser with `Parse()` and `FindPosition()` |
| `internal/adapter/github` | `PositionedFinding` type wrapping domain findings with diff position |

### Key Types

```go
// Diff parser
func Parse(patch string) (ParsedDiff, error)
func (pd ParsedDiff) FindPosition(lineNumber int) *int

// GitHub adapter
type PositionedFinding struct {
    Finding      domain.Finding
    DiffPosition *int  // nil = line not in diff
}
func MapFindings(findings []domain.Finding, diff domain.Diff) []PositionedFinding
```

## Test plan

- [x] 22 test cases covering parser and mapper
- [x] Edge cases: empty patches, malformed diffs, multiple hunks, deletions
- [x] Race detector passes
- [x] Full test suite passes
- [x] Build succeeds

Closes #9