### PR TITLE
feat: wire GitHub inline annotations into workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -32,13 +32,19 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Compare PR branch against base branch
           # github.head_ref = source branch (e.g., feature/foo)
           # github.event.pull_request.base.ref = target branch (e.g., main)
           ./cr review branch ${{ github.head_ref }} \
             --base ${{ github.event.pull_request.base.ref }} \
-            --output ./review-output
+            --output ./review-output \
+            --post-github-review \
+            --github-owner ${{ github.repository_owner }} \
+            --github-repo ${{ github.event.repository.name }} \
+            --pr-number ${{ github.event.pull_request.number }} \
+            --commit-sha ${{ github.event.pull_request.head.sha }}
 
       - name: Find review files
         id: find-files


### PR DESCRIPTION
## Summary
- Completes issue #10 by wiring up the GitHub PR Reviews API to post inline comments
- Findings now appear as inline comments on specific lines in the "Files Changed" tab

## Changes
- Add `GitHubPoster` interface and related types to orchestrator
- Add CLI flags: `--post-github-review`, `--github-owner`, `--github-repo`, `--pr-number`, `--commit-sha`
- Wire up `githubPosterAdapter` in main.go to bridge usecase and adapter layers
- Update GitHub Actions workflow to pass PR context flags

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Build succeeds (`go build -o cr ./cmd/cr`)
- [x] Verify inline annotations appear when this PR triggers the workflow

Closes #10