### PR TITLE
feat: add configurable review actions per severity level

### DIFF
--- a/cmd/cr/main.go
+++ b/cmd/cr/main.go
@@ -203,7 +203,14 @@ func run() error {
 		DefaultOutput:       cfg.Output.Directory,
 		DefaultRepo:         repoName,
 		DefaultInstructions: cfg.Review.Instructions,
-		Version:             version.Value(),
+		DefaultReviewActions: cli.DefaultReviewActions{
+			OnCritical: cfg.Review.Actions.OnCritical,
+			OnHigh:     cfg.Review.Actions.OnHigh,
+			OnMedium:   cfg.Review.Actions.OnMedium,
+			OnLow:      cfg.Review.Actions.OnLow,
+			OnClean:    cfg.Review.Actions.OnClean,
+		},
+		Version: version.Value(),
 	})
 
 	if err := root.ExecuteContext(ctx); err != nil {
@@ -545,7 +552,7 @@ func (a *githubPosterAdapter) PostReview(ctx context.Context, req review.GitHubP
 	// Map findings to positioned findings with diff positions
 	positionedFindings := githubadapter.MapFindings(req.Review.Findings, req.Diff)
 
-	// Build the post request
+	// Build the post request with review action configuration
 	postReq := usecasegithub.PostReviewRequest{
 		Owner:      req.Owner,
 		Repo:       req.Repo,
@@ -553,6 +560,13 @@ func (a *githubPosterAdapter) PostReview(ctx context.Context, req review.GitHubP
 		CommitSHA:  req.CommitSHA,
 		Review:     req.Review,
 		Findings:   positionedFindings,
+		ReviewActions: githubadapter.ReviewActions{
+			OnCritical: req.ActionOnCritical,
+			OnHigh:     req.ActionOnHigh,
+			OnMedium:   req.ActionOnMedium,
+			OnLow:      req.ActionOnLow,
+			OnClean:    req.ActionOnClean,
+		},
 	}
 
 	// Post the review

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -235,6 +235,13 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("providers.ollama.model", "llama2")
 	v.SetDefault("providers.static.enabled", true)
 	v.SetDefault("providers.static.model", "static-v1")
+
+	// Review action defaults (Phase 2) - configures GitHub review actions per severity
+	v.SetDefault("review.actions.onCritical", "request_changes")
+	v.SetDefault("review.actions.onHigh", "request_changes")
+	v.SetDefault("review.actions.onMedium", "comment")
+	v.SetDefault("review.actions.onLow", "comment")
+	v.SetDefault("review.actions.onClean", "approve")
 }
 
 func defaultStorePath() string {

--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -52,6 +52,11 @@ type PostReviewRequest struct {
 	// OverrideEvent optionally overrides the automatically determined event.
 	// If set, this event will be used instead of determining from severities.
 	OverrideEvent github.ReviewEvent
+
+	// ReviewActions configures the review action for each finding severity.
+	// If empty, sensible defaults are used (critical/high → request_changes,
+	// medium/low → comment, clean → approve).
+	ReviewActions github.ReviewActions
 }
 
 // PostReviewResult contains the result of posting a review.
@@ -88,7 +93,7 @@ func (p *ReviewPoster) PostReview(ctx context.Context, req PostReviewRequest) (*
 	if req.OverrideEvent != "" {
 		event = req.OverrideEvent
 	} else {
-		event = github.DetermineReviewEvent(req.Findings)
+		event = github.DetermineReviewEventWithActions(req.Findings, req.ReviewActions)
 	}
 
 	// Call the client


### PR DESCRIPTION
## Summary
- Implements configurable GitHub review actions (approve, comment, request_changes) based on finding severity levels
- Supports configuration via YAML config file, environment variables, and CLI flags
- Adds sensible defaults: critical/high → request_changes, medium/low → comment, clean → approve

## Test plan
- [x] Unit tests for `NormalizeAction()` - case-insensitive parsing
- [x] Unit tests for `DetermineReviewEventWithActions()` - config-driven event determination
- [x] Unit tests for config loading with defaults, file override, and env var override
- [x] Unit tests for config merging across layers
- [x] Unit tests for `ReviewPoster` with custom actions
- [x] All tests pass with race detector (`go test -race ./...`)
- [x] Binary builds successfully
- [x] CLI flags verified working

Closes #14