### PR TITLE
feat: add simplified deduplication for PR findings (#107)

### DIFF
--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -128,12 +128,15 @@ func (p *ReviewPoster) PostReview(ctx context.Context, req PostReviewRequest) (*
 	inDiffCount := github.CountInDiffFindings(findings)
 	skippedCount := len(findings) - inDiffCount
 
-	// Determine review event (using deduplicated findings)
+	// Determine review event using ORIGINAL findings, not deduplicated ones.
+	// This ensures the review status reflects the actual state of the code.
+	// If there are existing high-severity findings (already posted), we still
+	// need to REQUEST_CHANGES to keep the PR blocked.
 	var event github.ReviewEvent
 	if req.OverrideEvent != "" {
 		event = req.OverrideEvent
 	} else {
-		event = github.DetermineReviewEventWithActions(findings, req.ReviewActions)
+		event = github.DetermineReviewEventWithActions(req.Findings, req.ReviewActions)
 	}
 
 	// Call the client to create the new review first


### PR DESCRIPTION
## Summary
- Implement comment-based deduplication that checks existing PR comments before posting findings
- Add `ListPullRequestComments` to `ReviewClient` interface for fetching existing comments
- Add `DuplicatesSkipped` field to `PostReviewResult` to report deduplicated findings
- Use existing fingerprint infrastructure (`<!-- CR_FINGERPRINT:... -->`) for duplicate detection

## Test plan
- [x] All 28 tests pass in `internal/usecase/github`
- [x] 9 new deduplication tests cover all scenarios:
  - Basic deduplication (skip already-posted findings)
  - No duplicates when no existing comments
  - Ignores non-bot comments
  - Ignores comments without fingerprints (legacy)
  - Disabled when `BotUsername` is empty
  - Graceful degradation on comment fetch error
  - All findings deduplicated case
  - Case-insensitive bot username matching
- [x] Race detector passes
- [x] Linter passes (0 issues)
- [x] Build succeeds

Closes #107