### PR TITLE
fix: add nil response handling and OverrideEvent validation (#35, #36)

### DIFF
--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -162,11 +162,13 @@ type PostReviewResult struct {
 // counted in CommentsSkipped. Findings already posted (matching fingerprint)
 // are counted in DuplicatesSkipped.
 func (p *ReviewPoster) PostReview(ctx context.Context, req PostReviewRequest) (*PostReviewResult, error) {
-	// Validate OverrideEvent if set (Issue #36)
+	// Validate and normalize OverrideEvent if set (Issue #36)
 	if req.OverrideEvent != "" {
-		if _, valid := github.NormalizeAction(string(req.OverrideEvent)); !valid {
+		normalized, valid := github.NormalizeAction(string(req.OverrideEvent))
+		if !valid {
 			return nil, fmt.Errorf("invalid OverrideEvent: %q (must be APPROVE, REQUEST_CHANGES, or COMMENT)", req.OverrideEvent)
 		}
+		req.OverrideEvent = normalized
 	}
 
 	findings := req.Findings


### PR DESCRIPTION
## Summary

- **Fix #35**: Add nil response check in `PostReview` to prevent panic when `CreateReview` returns `(nil, nil)`. Returns a clear error message instead.
- **Fix #36**: Validate `OverrideEvent` before processing. Invalid values now return an actionable error message listing valid options (`APPROVE`, `REQUEST_CHANGES`, `COMMENT`) rather than causing a confusing GitHub API error downstream.

Note: Issue #66 was closed as stale - the `CommitExists`/`GetIncrementalDiff` functions it referenced are only used in tests since incremental reviews were deferred.

Closes #35
Closes #36

## Test plan

- [x] New test `TestReviewPoster_PostReview_NilResponse` verifies nil response returns error
- [x] New test `TestReviewPoster_PostReview_OverrideEventValidation` covers valid/invalid event types
- [x] All existing tests pass
- [x] Build succeeds