### PR TITLE
refactor: add Observable interface and WireObservability helper

### DIFF
--- a/cmd/cr/main.go
+++ b/cmd/cr/main.go
@@ -449,15 +449,7 @@ func createPlanningProvider(cfg *config.Config, providers map[string]review.Prov
 				return nil
 			}
 			client := openai.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			return openai.NewProvider(model, client)
 
 		case "anthropic":
@@ -466,15 +458,7 @@ func createPlanningProvider(cfg *config.Config, providers map[string]review.Prov
 				return nil
 			}
 			client := anthropic.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			return anthropic.NewProvider(model, client)
 
 		case "gemini":
@@ -483,15 +467,7 @@ func createPlanningProvider(cfg *config.Config, providers map[string]review.Prov
 				return nil
 			}
 			client := gemini.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			return gemini.NewProvider(model, client)
 
 		case "ollama":
@@ -501,15 +477,7 @@ func createPlanningProvider(cfg *config.Config, providers map[string]review.Prov
 				host = "http://localhost:11434"
 			}
 			client := ollama.NewHTTPClient(host, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			return ollama.NewProvider(model, client)
 
 		default:
@@ -552,15 +520,7 @@ func createMergeSynthesisProvider(cfg *config.Config, obs observabilityComponent
 			return nil
 		}
 		client := openai.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-		if obs.logger != nil {
-			client.SetLogger(obs.logger)
-		}
-		if obs.metrics != nil {
-			client.SetMetrics(obs.metrics)
-		}
-		if obs.pricing != nil {
-			client.SetPricing(obs.pricing)
-		}
+		llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 		log.Printf("Merge synthesis using %s/%s", providerName, model)
 		return openai.NewProvider(model, client)
 
@@ -570,15 +530,7 @@ func createMergeSynthesisProvider(cfg *config.Config, obs observabilityComponent
 			return nil
 		}
 		client := anthropic.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-		if obs.logger != nil {
-			client.SetLogger(obs.logger)
-		}
-		if obs.metrics != nil {
-			client.SetMetrics(obs.metrics)
-		}
-		if obs.pricing != nil {
-			client.SetPricing(obs.pricing)
-		}
+		llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 		log.Printf("Merge synthesis using %s/%s", providerName, model)
 		return anthropic.NewProvider(model, client)
 
@@ -588,15 +540,7 @@ func createMergeSynthesisProvider(cfg *config.Config, obs observabilityComponent
 			return nil
 		}
 		client := gemini.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-		if obs.logger != nil {
-			client.SetLogger(obs.logger)
-		}
-		if obs.metrics != nil {
-			client.SetMetrics(obs.metrics)
-		}
-		if obs.pricing != nil {
-			client.SetPricing(obs.pricing)
-		}
+		llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 		log.Printf("Merge synthesis using %s/%s", providerName, model)
 		return gemini.NewProvider(model, client)
 
@@ -606,15 +550,7 @@ func createMergeSynthesisProvider(cfg *config.Config, obs observabilityComponent
 			host = "http://localhost:11434"
 		}
 		client := ollama.NewHTTPClient(host, model, providerCfg, cfg.HTTP)
-		if obs.logger != nil {
-			client.SetLogger(obs.logger)
-		}
-		if obs.metrics != nil {
-			client.SetMetrics(obs.metrics)
-		}
-		if obs.pricing != nil {
-			client.SetPricing(obs.pricing)
-		}
+		llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 		log.Printf("Merge synthesis using %s/%s", providerName, model)
 		return ollama.NewProvider(model, client)
 
@@ -641,16 +577,7 @@ func buildProviders(providersConfig map[string]config.ProviderConfig, httpConfig
 			providers["openai"] = openai.NewProvider(model, openai.NewStaticClient())
 		} else {
 			client := openai.NewHTTPClient(apiKey, model, cfg, httpConfig)
-			// Wire up observability
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			providers["openai"] = openai.NewProvider(model, client)
 		}
 	}
@@ -667,16 +594,7 @@ func buildProviders(providersConfig map[string]config.ProviderConfig, httpConfig
 			log.Println("Anthropic: No API key provided, skipping provider")
 		} else {
 			client := anthropic.NewHTTPClient(apiKey, model, cfg, httpConfig)
-			// Wire up observability
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			providers["anthropic"] = anthropic.NewProvider(model, client)
 		}
 	}
@@ -693,16 +611,7 @@ func buildProviders(providersConfig map[string]config.ProviderConfig, httpConfig
 			log.Println("Gemini: No API key provided, skipping provider")
 		} else {
 			client := gemini.NewHTTPClient(apiKey, model, cfg, httpConfig)
-			// Wire up observability
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.metrics != nil {
-				client.SetMetrics(obs.metrics)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			providers["gemini"] = gemini.NewProvider(model, client)
 		}
 	}
@@ -719,16 +628,7 @@ func buildProviders(providersConfig map[string]config.ProviderConfig, httpConfig
 			host = "http://localhost:11434"
 		}
 		client := ollama.NewHTTPClient(host, model, cfg, httpConfig)
-		// Wire up observability
-		if obs.logger != nil {
-			client.SetLogger(obs.logger)
-		}
-		if obs.metrics != nil {
-			client.SetMetrics(obs.metrics)
-		}
-		if obs.pricing != nil {
-			client.SetPricing(obs.pricing)
-		}
+		llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 		providers["ollama"] = ollama.NewProvider(model, client)
 	}
 
@@ -880,30 +780,15 @@ func createVerifier(cfg config.Config, providers map[string]review.Provider, rep
 		switch name {
 		case "gemini":
 			client := gemini.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			llmClient = &geminiLLMAdapter{client: client, maxTokens: maxTokens}
 		case "anthropic":
 			client := anthropic.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			llmClient = &anthropicLLMAdapter{client: client, maxTokens: maxTokens}
 		case "openai":
 			client := openai.NewHTTPClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-			if obs.logger != nil {
-				client.SetLogger(obs.logger)
-			}
-			if obs.pricing != nil {
-				client.SetPricing(obs.pricing)
-			}
+			llmhttp.WireObservability(client, obs.logger, obs.metrics, obs.pricing)
 			llmClient = &openaiLLMAdapter{client: client, maxTokens: maxTokens}
 		}
 

--- a/internal/adapter/llm/http/observable.go
+++ b/internal/adapter/llm/http/observable.go
@@ -1,0 +1,36 @@
+package http
+
+// Observable defines the interface for types that accept observability components.
+// All LLM HTTP clients implement this interface through their SetLogger, SetMetrics,
+// and SetPricing methods.
+//
+// This interface enables centralized wiring of observability concerns via the
+// WireObservability helper function, eliminating repetitive nil-check boilerplate.
+type Observable interface {
+	SetLogger(logger Logger)
+	SetMetrics(metrics Metrics)
+	SetPricing(pricing Pricing)
+}
+
+// WireObservability configures an Observable with logger, metrics, and pricing.
+// Each component is only set if non-nil, allowing partial observability configuration.
+// If obs is nil, this function is a no-op.
+//
+// Example usage:
+//
+//	client := anthropic.NewHTTPClient(apiKey, model, cfg, httpConfig)
+//	llmhttp.WireObservability(client, logger, metrics, pricing)
+func WireObservability(obs Observable, logger Logger, metrics Metrics, pricing Pricing) {
+	if obs == nil {
+		return
+	}
+	if logger != nil {
+		obs.SetLogger(logger)
+	}
+	if metrics != nil {
+		obs.SetMetrics(metrics)
+	}
+	if pricing != nil {
+		obs.SetPricing(pricing)
+	}
+}

--- a/internal/adapter/llm/http/observable_test.go
+++ b/internal/adapter/llm/http/observable_test.go
@@ -1,0 +1,139 @@
+package http
+
+import (
+	"testing"
+)
+
+// mockObservable tracks which setter methods were called.
+type mockObservable struct {
+	loggerSet  bool
+	metricsSet bool
+	pricingSet bool
+	logger     Logger
+	metrics    Metrics
+	pricing    Pricing
+}
+
+func (m *mockObservable) SetLogger(logger Logger) {
+	m.loggerSet = true
+	m.logger = logger
+}
+
+func (m *mockObservable) SetMetrics(metrics Metrics) {
+	m.metricsSet = true
+	m.metrics = metrics
+}
+
+func (m *mockObservable) SetPricing(pricing Pricing) {
+	m.pricingSet = true
+	m.pricing = pricing
+}
+
+func TestWireObservability(t *testing.T) {
+	t.Run("wires all components when all provided", func(t *testing.T) {
+		obs := &mockObservable{}
+		logger := NewDefaultLogger(LogLevelInfo, LogFormatHuman, true)
+		metrics := NewDefaultMetrics()
+		pricing := NewDefaultPricing()
+
+		WireObservability(obs, logger, metrics, pricing)
+
+		if !obs.loggerSet {
+			t.Error("expected logger to be set")
+		}
+		if !obs.metricsSet {
+			t.Error("expected metrics to be set")
+		}
+		if !obs.pricingSet {
+			t.Error("expected pricing to be set")
+		}
+		if obs.logger != logger {
+			t.Error("expected logger to match provided instance")
+		}
+		if obs.metrics != metrics {
+			t.Error("expected metrics to match provided instance")
+		}
+		if obs.pricing != pricing {
+			t.Error("expected pricing to match provided instance")
+		}
+	})
+
+	t.Run("skips nil logger", func(t *testing.T) {
+		obs := &mockObservable{}
+		metrics := NewDefaultMetrics()
+		pricing := NewDefaultPricing()
+
+		WireObservability(obs, nil, metrics, pricing)
+
+		if obs.loggerSet {
+			t.Error("expected logger NOT to be set when nil")
+		}
+		if !obs.metricsSet {
+			t.Error("expected metrics to be set")
+		}
+		if !obs.pricingSet {
+			t.Error("expected pricing to be set")
+		}
+	})
+
+	t.Run("skips nil metrics", func(t *testing.T) {
+		obs := &mockObservable{}
+		logger := NewDefaultLogger(LogLevelInfo, LogFormatHuman, true)
+		pricing := NewDefaultPricing()
+
+		WireObservability(obs, logger, nil, pricing)
+
+		if !obs.loggerSet {
+			t.Error("expected logger to be set")
+		}
+		if obs.metricsSet {
+			t.Error("expected metrics NOT to be set when nil")
+		}
+		if !obs.pricingSet {
+			t.Error("expected pricing to be set")
+		}
+	})
+
+	t.Run("skips nil pricing", func(t *testing.T) {
+		obs := &mockObservable{}
+		logger := NewDefaultLogger(LogLevelInfo, LogFormatHuman, true)
+		metrics := NewDefaultMetrics()
+
+		WireObservability(obs, logger, metrics, nil)
+
+		if !obs.loggerSet {
+			t.Error("expected logger to be set")
+		}
+		if !obs.metricsSet {
+			t.Error("expected metrics to be set")
+		}
+		if obs.pricingSet {
+			t.Error("expected pricing NOT to be set when nil")
+		}
+	})
+
+	t.Run("handles all nil components", func(t *testing.T) {
+		obs := &mockObservable{}
+
+		WireObservability(obs, nil, nil, nil)
+
+		if obs.loggerSet {
+			t.Error("expected logger NOT to be set")
+		}
+		if obs.metricsSet {
+			t.Error("expected metrics NOT to be set")
+		}
+		if obs.pricingSet {
+			t.Error("expected pricing NOT to be set")
+		}
+	})
+
+	t.Run("handles nil Observable without panic", func(t *testing.T) {
+		logger := NewDefaultLogger(LogLevelInfo, LogFormatHuman, true)
+		metrics := NewDefaultMetrics()
+		pricing := NewDefaultPricing()
+
+		// Should not panic when Observable is nil
+		WireObservability(nil, logger, metrics, pricing)
+	})
+}


### PR DESCRIPTION
## Summary

- Introduces `Observable` interface in `internal/adapter/llm/http/observable.go` that abstracts the common setter methods (SetLogger, SetMetrics, SetPricing) across all LLM clients
- Adds `WireObservability` helper function that wires all observability components with nil-safe checks
- Replaces 15 repetitive wiring blocks in `cmd/cr/main.go` with single-line calls
- Reduces ~120 lines of boilerplate code

**Bonus fix:** Also fixes a bug where `createVerifier()` was only wiring logger and pricing (missing metrics), ensuring verifier LLM calls are now properly tracked.

## Test plan

- [x] New unit tests in `observable_test.go` cover all nil permutations
- [x] All existing tests pass (`mage test`)
- [x] Lint passes (`mage lint`)
- [x] Build succeeds (`mage buildAll`)

Closes #163
Fixes #166