### PR TITLE
feat: improve semantic deduplication to reduce repeat findings (#165)

### DIFF
--- a/internal/domain/triaged_finding.go
+++ b/internal/domain/triaged_finding.go
@@ -82,6 +82,17 @@ func (c TriagedFindingContext) DisputedFindings() []TriagedFinding {
 	return result
 }
 
+// OpenFindings returns findings with StatusOpen (posted but not yet replied to).
+func (c TriagedFindingContext) OpenFindings() []TriagedFinding {
+	var result []TriagedFinding
+	for _, f := range c.Findings {
+		if f.Status == StatusOpen {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
 // FilterByReviewer returns a new TriagedFindingContext containing only
 // findings from the specified reviewer. Returns nil if no matching findings.
 // Part of Phase 3.2 - Reviewer Personas.
@@ -115,4 +126,9 @@ func StatusReasonForAcknowledged() string {
 // StatusReasonForDisputed returns a human-readable reason for disputed status.
 func StatusReasonForDisputed() string {
 	return "Author disputed as false positive or not applicable"
+}
+
+// StatusReasonForOpen returns a human-readable reason for open status.
+func StatusReasonForOpen() string {
+	return "Previously raised - awaiting author response"
 }

--- a/internal/usecase/dedup/candidates.go
+++ b/internal/usecase/dedup/candidates.go
@@ -4,8 +4,13 @@ import (
 	"github.com/bkyoung/code-reviewer/internal/domain"
 )
 
-// FindCandidates identifies new findings that spatially overlap with existing findings.
-// Two findings overlap if they are in the same file and within lineThreshold lines of each other.
+// FindCandidates identifies new findings that may be semantic duplicates of existing findings.
+// Two findings are candidates for comparison if they are in the same file AND either:
+//   - Within lineThreshold lines of each other (spatial proximity), OR
+//   - Have the same category AND severity (content match, regardless of line distance)
+//
+// The content match criterion catches cases where code shifts between review rounds
+// cause the same conceptual finding to appear at distant line numbers (Issue #165).
 //
 // Returns candidate pairs for semantic comparison, limited to maxCandidates.
 // If there are more candidates than maxCandidates, the excess are returned as overflow
@@ -37,9 +42,13 @@ func FindCandidates(
 			continue
 		}
 
-		// Check spatial proximity with each existing finding
+		// Check each existing finding for spatial OR content match
 		for _, ef := range fileExisting {
-			if linesOverlap(nf.LineStart, nf.LineEnd, ef.LineStart, ef.LineEnd, lineThreshold) {
+			// Match criteria: spatial proximity OR content match (same category+severity)
+			spatialMatch := linesOverlap(nf.LineStart, nf.LineEnd, ef.LineStart, ef.LineEnd, lineThreshold)
+			contentMatch := contentMatches(nf, ef)
+
+			if spatialMatch || contentMatch {
 				if len(candidates) >= maxCandidates {
 					// Hit the limit - remaining paired findings go to overflow
 					if !paired[i] {
@@ -59,6 +68,12 @@ func FindCandidates(
 	}
 
 	return candidates, overflow
+}
+
+// contentMatches returns true if findings have the same category AND severity.
+// This catches semantic duplicates that may have shifted to distant line numbers.
+func contentMatches(nf domain.Finding, ef ExistingFinding) bool {
+	return nf.Category == ef.Category && nf.Severity == ef.Severity
 }
 
 // linesOverlap returns true if two line ranges are within threshold lines of each other.

--- a/internal/usecase/dedup/candidates_test.go
+++ b/internal/usecase/dedup/candidates_test.go
@@ -165,16 +165,16 @@ func TestFindCandidates(t *testing.T) {
 			wantOverflow:   0,
 		},
 		{
-			name: "same file outside threshold",
+			name: "same file outside threshold with different content",
 			newFindings: []domain.Finding{
-				{File: "foo.go", LineStart: 50, LineEnd: 55, Description: "new finding"},
+				{File: "foo.go", LineStart: 50, LineEnd: 55, Category: "bug", Severity: "high", Description: "new finding"},
 			},
 			existing: []ExistingFinding{
-				{File: "foo.go", LineStart: 10, LineEnd: 15, Description: "existing finding"},
+				{File: "foo.go", LineStart: 10, LineEnd: 15, Category: "security", Severity: "medium", Description: "existing finding"},
 			},
 			lineThreshold:  10,
 			maxCandidates:  50,
-			wantCandidates: 0,
+			wantCandidates: 0, // No spatial match (outside threshold) and no content match (different category/severity)
 			wantOverflow:   0,
 		},
 		{
@@ -188,6 +188,19 @@ func TestFindCandidates(t *testing.T) {
 			lineThreshold:  10,
 			maxCandidates:  50,
 			wantCandidates: 0,
+			wantOverflow:   0,
+		},
+		{
+			name: "content match catches distant findings with same category and severity",
+			newFindings: []domain.Finding{
+				{File: "foo.go", LineStart: 500, LineEnd: 510, Category: "security", Severity: "high", Description: "SQL injection risk"},
+			},
+			existing: []ExistingFinding{
+				{File: "foo.go", LineStart: 10, LineEnd: 15, Category: "security", Severity: "high", Description: "SQL injection vulnerability"},
+			},
+			lineThreshold:  10,
+			maxCandidates:  50,
+			wantCandidates: 1, // Content match: same category+severity, even though 490 lines apart
 			wantOverflow:   0,
 		},
 		{
@@ -207,19 +220,19 @@ func TestFindCandidates(t *testing.T) {
 		{
 			name: "max candidates exceeded",
 			newFindings: []domain.Finding{
-				{File: "foo.go", LineStart: 10, LineEnd: 15, Description: "new 1"},
-				{File: "foo.go", LineStart: 100, LineEnd: 105, Description: "new 2"},
-				{File: "foo.go", LineStart: 200, LineEnd: 205, Description: "new 3"},
+				{File: "foo.go", LineStart: 10, LineEnd: 15, Category: "bug", Severity: "high", Description: "new 1"},
+				{File: "foo.go", LineStart: 100, LineEnd: 105, Category: "perf", Severity: "low", Description: "new 2"},
+				{File: "foo.go", LineStart: 200, LineEnd: 205, Category: "style", Severity: "info", Description: "new 3"},
 			},
 			existing: []ExistingFinding{
-				{File: "foo.go", LineStart: 12, LineEnd: 18, Description: "existing 1"},
-				{File: "foo.go", LineStart: 102, LineEnd: 108, Description: "existing 2"},
-				{File: "foo.go", LineStart: 202, LineEnd: 208, Description: "existing 3"},
+				{File: "foo.go", LineStart: 12, LineEnd: 18, Category: "bug", Severity: "high", Description: "existing 1"},
+				{File: "foo.go", LineStart: 102, LineEnd: 108, Category: "perf", Severity: "low", Description: "existing 2"},
+				{File: "foo.go", LineStart: 202, LineEnd: 208, Category: "style", Severity: "info", Description: "existing 3"},
 			},
 			lineThreshold:  10,
 			maxCandidates:  2,
 			wantCandidates: 2,
-			wantOverflow:   1, // Third new finding goes to overflow
+			wantOverflow:   1, // Third new finding goes to overflow (each matches only its corresponding existing)
 		},
 	}
 

--- a/internal/usecase/dedup/dedup.go
+++ b/internal/usecase/dedup/dedup.go
@@ -101,7 +101,7 @@ func DefaultConfig() Config {
 		Provider:      "anthropic",
 		Model:         "claude-haiku-4-5",
 		MaxTokens:     64000,
-		LineThreshold: 10,
+		LineThreshold: 50, // Increased from 10 to catch more duplicates (Issue #165)
 		MaxCandidates: 50,
 	}
 }

--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -43,7 +43,7 @@ type SemanticDedupConfig struct {
 // DefaultSemanticDedupConfig returns sensible defaults for semantic deduplication.
 func DefaultSemanticDedupConfig() SemanticDedupConfig {
 	return SemanticDedupConfig{
-		LineThreshold: 10,
+		LineThreshold: 50, // Increased from 10 to catch more duplicates (Issue #165)
 		MaxCandidates: 50,
 	}
 }

--- a/internal/usecase/github/triage_fetcher.go
+++ b/internal/usecase/github/triage_fetcher.go
@@ -29,9 +29,13 @@ func NewTriageContextFetcher(client ReviewClient, botUsername string) *TriageCon
 	}
 }
 
-// FetchTriagedFindings retrieves findings that have been acknowledged or disputed.
-// Returns nil if there are no triaged findings, if the bot username is not set,
+// FetchTriagedFindings retrieves ALL previously posted bot findings for a PR.
+// This includes findings with any status: open, acknowledged, or disputed.
+// Returns nil if there are no findings, if the bot username is not set,
 // or if fetching fails. Errors are logged but not returned to avoid blocking the review.
+//
+// Including all findings (not just acknowledged/disputed) prevents the LLM from
+// re-raising issues that were already posted in earlier review rounds (Issue #165).
 //
 // This method satisfies the review.TriageContextFetcher interface.
 func (f *TriageContextFetcher) FetchTriagedFindings(
@@ -94,11 +98,9 @@ func (f *TriageContextFetcher) extractTriagedFindings(
 			continue // Not a structured finding comment
 		}
 
-		// Check if this finding has a triaged status
-		status, exists := statuses[fp]
-		if !exists || status == domain.StatusOpen {
-			continue // Only include acknowledged or disputed findings
-		}
+		// Get status if available (may be empty for findings with no replies)
+		// Include ALL bot findings regardless of status to prevent LLM from re-raising them
+		status := statuses[fp]
 
 		// Extract structured details
 		details := github.ExtractCommentDetails(comment.Body)
@@ -134,6 +136,10 @@ func (f *TriageContextFetcher) extractTriagedFindings(
 			tf.StatusReason = domain.StatusReasonForAcknowledged()
 		case domain.StatusDisputed:
 			tf.StatusReason = domain.StatusReasonForDisputed()
+		default:
+			// StatusOpen or empty - finding was posted but not yet replied to
+			tf.Status = domain.StatusOpen
+			tf.StatusReason = domain.StatusReasonForOpen()
 		}
 
 		findings = append(findings, tf)

--- a/internal/usecase/github/triage_fetcher_test.go
+++ b/internal/usecase/github/triage_fetcher_test.go
@@ -54,9 +54,10 @@ func TestTriageContextFetcher_NoComments(t *testing.T) {
 	assert.Nil(t, result, "should return nil when no comments")
 }
 
-func TestTriageContextFetcher_NoTriagedFindings(t *testing.T) {
-	// Comments exist but none have triage status (all open)
+func TestTriageContextFetcher_OpenFinding(t *testing.T) {
+	// Issue #165: Open findings (no reply yet) should be included to prevent LLM from re-raising them
 	fingerprint := domain.NewFindingFingerprint("main.go", "bug", "high", "Test issue")
+	line := 10
 	client := &mockReviewClientForTriage{
 		comments: []github.PullRequestComment{
 			{
@@ -64,13 +65,22 @@ func TestTriageContextFetcher_NoTriagedFindings(t *testing.T) {
 				Path: "main.go",
 				Body: buildFindingComment("bug", "high", "Test issue", 10, 10, fingerprint),
 				User: github.User{Login: "github-actions[bot]", Type: "Bot"},
+				Line: &line,
 			},
 		},
 	}
 	fetcher := NewTriageContextFetcher(client, "github-actions[bot]")
 
 	result := fetcher.FetchTriagedFindings(context.Background(), "owner", "repo", 123)
-	assert.Nil(t, result, "should return nil when no triaged findings")
+
+	require.NotNil(t, result, "should return context with open finding")
+	require.Len(t, result.Findings, 1)
+
+	f := result.Findings[0]
+	assert.Equal(t, "main.go", f.File)
+	assert.Equal(t, domain.StatusOpen, f.Status)
+	assert.Equal(t, "bug", f.Category)
+	assert.Contains(t, f.StatusReason, "awaiting")
 }
 
 func TestTriageContextFetcher_AcknowledgedFinding(t *testing.T) {
@@ -141,7 +151,7 @@ func TestTriageContextFetcher_DisputedFinding(t *testing.T) {
 }
 
 func TestTriageContextFetcher_MixedFindings(t *testing.T) {
-	// Create findings: one acknowledged, one disputed, one open
+	// Issue #165: All findings should be included (acknowledged, disputed, AND open)
 	fp1 := domain.NewFindingFingerprint("a.go", "security", "high", "Issue 1")
 	fp2 := domain.NewFindingFingerprint("b.go", "bug", "medium", "Issue 2")
 	fp3 := domain.NewFindingFingerprint("c.go", "performance", "low", "Issue 3")
@@ -193,23 +203,28 @@ func TestTriageContextFetcher_MixedFindings(t *testing.T) {
 	result := fetcher.FetchTriagedFindings(context.Background(), "owner", "repo", 123)
 
 	require.NotNil(t, result)
-	// Should only include acknowledged and disputed (not open)
-	assert.Len(t, result.Findings, 2)
+	// Issue #165: Should include ALL findings (acknowledged, disputed, AND open)
+	assert.Len(t, result.Findings, 3)
 
-	// Check we got the right findings
-	var hasAcknowledged, hasDisputed bool
+	// Check we got all three findings with correct statuses
+	var hasAcknowledged, hasDisputed, hasOpen bool
 	for _, f := range result.Findings {
-		if f.Status == domain.StatusAcknowledged {
+		switch f.Status {
+		case domain.StatusAcknowledged:
 			hasAcknowledged = true
 			assert.Equal(t, "a.go", f.File)
-		}
-		if f.Status == domain.StatusDisputed {
+		case domain.StatusDisputed:
 			hasDisputed = true
 			assert.Equal(t, "b.go", f.File)
+		case domain.StatusOpen:
+			hasOpen = true
+			assert.Equal(t, "c.go", f.File)
+			assert.Contains(t, f.StatusReason, "awaiting")
 		}
 	}
 	assert.True(t, hasAcknowledged, "should have acknowledged finding")
 	assert.True(t, hasDisputed, "should have disputed finding")
+	assert.True(t, hasOpen, "should have open finding")
 }
 
 func TestTriageContextFetcher_MatchesBotUsername(t *testing.T) {

--- a/internal/usecase/review/prompt_builder.go
+++ b/internal/usecase/review/prompt_builder.go
@@ -475,6 +475,22 @@ func formatPriorFindings(ctx *domain.TriagedFindingContext) string {
 		}
 	}
 
+	// Format open findings (previously posted but not yet replied to)
+	open := ctx.OpenFindings()
+	if len(open) > 0 {
+		sb.WriteString("### Previously Posted Findings (do NOT re-raise)\n\n")
+		sb.WriteString("The following concerns were already raised in earlier review rounds. ")
+		sb.WriteString("Do not raise similar findings - they are already posted and awaiting response:\n\n")
+		for i, f := range open {
+			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d)\n",
+				i+1, f.Category, f.File, f.LineStart, f.LineEnd))
+			// Indent continuation lines to maintain Markdown list structure
+			indentedDesc := strings.ReplaceAll(f.Description, "\n", "\n     ")
+			sb.WriteString(fmt.Sprintf("   - %s\n", indentedDesc))
+			sb.WriteString(fmt.Sprintf("   - Status: %s\n\n", f.StatusReason))
+		}
+	}
+
 	return sb.String()
 }
 

--- a/internal/usecase/review/prompt_builder_test.go
+++ b/internal/usecase/review/prompt_builder_test.go
@@ -829,23 +829,38 @@ func TestFormatPriorFindings_NoFindings(t *testing.T) {
 }
 
 func TestFormatPriorFindings_OnlyOpenFindings(t *testing.T) {
-	// Open findings should not appear in prior findings (they haven't been addressed)
+	// Issue #165: Open findings SHOULD appear to prevent LLM from re-raising them
 	ctx := &domain.TriagedFindingContext{
 		PRNumber: 123,
 		Findings: []domain.TriagedFinding{
 			{
-				File:        "main.go",
-				LineStart:   10,
-				LineEnd:     15,
-				Category:    "security",
-				Description: "Open issue",
-				Status:      domain.StatusOpen,
+				File:         "main.go",
+				LineStart:    10,
+				LineEnd:      15,
+				Category:     "security",
+				Description:  "Open issue",
+				Status:       domain.StatusOpen,
+				StatusReason: "Previously raised - awaiting author response",
 			},
 		},
 	}
 	result := formatPriorFindings(ctx)
-	if result != "" {
-		t.Errorf("expected empty string for open-only findings, got: %q", result)
+
+	// Should contain open findings section
+	if !strings.Contains(result, "Previously Posted Findings") {
+		t.Error("expected 'Previously Posted Findings' header for open findings")
+	}
+	if !strings.Contains(result, "do NOT re-raise") {
+		t.Error("expected instruction not to re-raise")
+	}
+	if !strings.Contains(result, "main.go") {
+		t.Error("expected file name in output")
+	}
+	if !strings.Contains(result, "security") {
+		t.Error("expected category in output")
+	}
+	if !strings.Contains(result, "awaiting") {
+		t.Error("expected status reason mentioning awaiting response")
 	}
 }
 
@@ -924,6 +939,7 @@ func TestFormatPriorFindings_DisputedFindings(t *testing.T) {
 }
 
 func TestFormatPriorFindings_MixedFindings(t *testing.T) {
+	// Issue #165: All findings (acknowledged, disputed, AND open) should appear
 	ctx := &domain.TriagedFindingContext{
 		PRNumber: 123,
 		Findings: []domain.TriagedFinding{
@@ -950,33 +966,35 @@ func TestFormatPriorFindings_MixedFindings(t *testing.T) {
 				LineStart:    1,
 				LineEnd:      1,
 				Category:     "bug",
-				Description:  "Open bug - should not appear",
+				Description:  "Open bug awaiting response",
 				Status:       domain.StatusOpen,
-				StatusReason: "",
+				StatusReason: "Previously raised - awaiting author response",
 			},
 		},
 	}
 	result := formatPriorFindings(ctx)
 
-	// Should contain both sections
+	// Should contain all three sections
 	if !strings.Contains(result, "Acknowledged Findings") {
 		t.Error("expected 'Acknowledged Findings' header")
 	}
 	if !strings.Contains(result, "Disputed Findings") {
 		t.Error("expected 'Disputed Findings' header")
 	}
+	if !strings.Contains(result, "Previously Posted Findings") {
+		t.Error("expected 'Previously Posted Findings' header for open findings")
+	}
 
-	// Should contain acknowledged and disputed findings
+	// Should contain all findings
 	if !strings.Contains(result, "Acknowledged security issue") {
 		t.Error("expected acknowledged finding description")
 	}
 	if !strings.Contains(result, "Disputed performance issue") {
 		t.Error("expected disputed finding description")
 	}
-
-	// Should NOT contain open findings
-	if strings.Contains(result, "Open bug") {
-		t.Error("open findings should not appear in prior findings")
+	// Issue #165: Open findings SHOULD now appear
+	if !strings.Contains(result, "Open bug awaiting response") {
+		t.Error("expected open finding description (Issue #165)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implement three improvements to reduce repeat findings across review rounds (Issue #165)
- Include ALL findings (including open) in LLM prompt to prevent re-raising already-posted issues
- Add content-based candidate matching (category+severity) to catch duplicates that shifted line numbers
- Increase default line threshold from 10 to 50 for more aggressive spatial matching

## Test plan

- [x] Run `mage ci` - all tests pass
- [x] Verify `TestFormatPriorFindings_OnlyOpenFindings` now expects open findings in output
- [x] Verify `TestFormatPriorFindings_MixedFindings` expects all three status types
- [x] Verify `TestTriageContextFetcher_OpenFinding` confirms open findings are returned
- [x] Verify `TestFindCandidates` includes content matching test case
- [x] Lint passes with 0 issues
- [x] Race detector passes