### PR TITLE
feat(mcp): Phase 3.5d MCP Review Tools

### DIFF
--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -1,0 +1,550 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bkyoung/code-reviewer/internal/domain"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// =============================================================================
+// Review Tool Handlers (Phase 3.5d - MCP Review Tools)
+// =============================================================================
+
+// registerEditFindingTool registers the edit_finding tool.
+func (s *Server) registerEditFindingTool() {
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "edit_finding",
+		Description: `Edit a finding's properties and return the modified finding.
+
+This is a pure transformation tool - it takes a finding, applies optional overrides,
+and returns a new finding with updated fingerprint. The original finding is unchanged.
+
+Use this to:
+- Adjust severity if the LLM was too aggressive/lenient
+- Recategorize findings (e.g., "maintainability" → "security")
+- Refine descriptions before posting to GitHub
+- Filter findings by modifying and selectively posting`,
+	}, s.handleEditFinding)
+}
+
+func (s *Server) handleEditFinding(ctx context.Context, req *mcp.CallToolRequest, input EditFindingInput) (*mcp.CallToolResult, EditFindingOutput, error) {
+	// Convert input to domain finding
+	finding := findingInputToDomain(input.Finding)
+
+	// Track what fields were modified
+	var modified []string
+
+	// Apply overrides
+	if input.Severity != nil {
+		// Validate severity
+		if !isValidSeverity(*input.Severity) {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("Invalid severity: %q. Valid values: %v", *input.Severity, ValidSeverities)},
+				},
+			}, EditFindingOutput{}, nil
+		}
+		finding.Severity = *input.Severity
+		modified = append(modified, "severity")
+	}
+
+	if input.Category != nil {
+		finding.Category = *input.Category
+		modified = append(modified, "category")
+	}
+
+	if input.Description != nil {
+		finding.Description = *input.Description
+		modified = append(modified, "description")
+	}
+
+	if input.Suggestion != nil {
+		finding.Suggestion = *input.Suggestion
+		modified = append(modified, "suggestion")
+	}
+
+	// Convert to output (includes fingerprint calculation)
+	output := domainFindingToOutput(finding)
+
+	// Build result message
+	var msg string
+	fpShort := truncateFingerprint(output.Fingerprint, 16)
+	if len(modified) == 0 {
+		msg = fmt.Sprintf("Finding unchanged (fingerprint: %s)", fpShort)
+	} else {
+		msg = fmt.Sprintf("Modified %s (fingerprint: %s)", strings.Join(modified, ", "), fpShort)
+	}
+
+	return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: msg},
+			},
+		}, EditFindingOutput{
+			Finding:        output,
+			FieldsModified: modified,
+			Message:        msg,
+		}, nil
+}
+
+// =============================================================================
+// Conversion Helpers
+// =============================================================================
+
+// findingInputToDomain converts an MCP FindingInput to a domain.Finding.
+func findingInputToDomain(input FindingInput) domain.Finding {
+	return domain.Finding{
+		ID:             input.ID,
+		File:           input.File,
+		LineStart:      input.LineStart,
+		LineEnd:        input.LineEnd,
+		Severity:       input.Severity,
+		Category:       input.Category,
+		Description:    input.Description,
+		Suggestion:     input.Suggestion,
+		ReviewerName:   input.ReviewerName,
+		ReviewerWeight: input.ReviewerWeight,
+	}
+}
+
+// getFingerprintFromInput returns the fingerprint for a FindingInput.
+// If the input has a preserved fingerprint, it's returned as-is.
+// Otherwise, a new fingerprint is computed from the domain representation.
+func getFingerprintFromInput(input FindingInput) string {
+	if input.Fingerprint != "" {
+		return input.Fingerprint
+	}
+	return string(findingInputToDomain(input).Fingerprint())
+}
+
+// domainFindingToOutput converts a domain.Finding to an MCP FindingOutput.
+func domainFindingToOutput(f domain.Finding) FindingOutput {
+	return FindingOutput{
+		ID:             f.ID,
+		Fingerprint:    string(f.Fingerprint()),
+		File:           f.File,
+		LineStart:      f.LineStart,
+		LineEnd:        f.LineEnd,
+		Severity:       f.Severity,
+		Category:       f.Category,
+		Description:    f.Description,
+		Suggestion:     f.Suggestion,
+		ReviewerName:   f.ReviewerName,
+		ReviewerWeight: f.ReviewerWeight,
+	}
+}
+
+// domainFindingsToOutput converts a slice of domain.Finding to FindingOutput.
+func domainFindingsToOutput(findings []domain.Finding) []FindingOutput {
+	output := make([]FindingOutput, len(findings))
+	for i, f := range findings {
+		output[i] = domainFindingToOutput(f)
+	}
+	return output
+}
+
+// =============================================================================
+// review_pr Tool
+// =============================================================================
+
+// registerReviewPRTool registers the review_pr tool.
+func (s *Server) registerReviewPRTool() {
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "review_pr",
+		Description: `Review a GitHub pull request and return findings.
+
+This tool invokes code reviewers on a PR's diff and returns findings WITHOUT posting to GitHub.
+The caller can then filter/modify findings using edit_finding and post selected ones using post_findings.
+
+Use this for:
+- Running code review on any accessible PR
+- Getting findings for human review before posting
+- Filtering out false positives before they appear on the PR`,
+	}, s.handleReviewPR)
+}
+
+func (s *Server) handleReviewPR(ctx context.Context, req *mcp.CallToolRequest, input ReviewPRInput) (*mcp.CallToolResult, ReviewPROutput, error) {
+	if s.deps.PRReviewer == nil {
+		return notImplementedResult("review_pr - PRReviewer not configured"), ReviewPROutput{}, nil
+	}
+
+	// Validate inputs
+	if input.Owner == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "owner is required"},
+			},
+		}, ReviewPROutput{}, nil
+	}
+	if input.Repo == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "repo is required"},
+			},
+		}, ReviewPROutput{}, nil
+	}
+	if input.PRNumber <= 0 {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("invalid PR number: %d (must be positive)", input.PRNumber)},
+			},
+		}, ReviewPROutput{}, nil
+	}
+
+	// Build PRRequest
+	prReq := review.PRRequest{
+		Owner:        input.Owner,
+		Repo:         input.Repo,
+		PRNumber:     input.PRNumber,
+		Reviewers:    input.Reviewers,
+		PostToGitHub: false, // Never post - that's what post_findings is for
+	}
+
+	// Invoke review
+	result, err := s.deps.PRReviewer.ReviewPR(ctx, prReq)
+	if err != nil {
+		return nil, ReviewPROutput{}, fmt.Errorf("review PR: %w", err)
+	}
+
+	// Aggregate findings from all reviews
+	var allFindings []domain.Finding
+	var totalTokensIn, totalTokensOut int
+	var totalCost float64
+
+	for _, r := range result.Reviews {
+		allFindings = append(allFindings, r.Findings...)
+		totalTokensIn += r.TokensIn
+		totalTokensOut += r.TokensOut
+		totalCost += r.Cost
+	}
+
+	// Build output
+	output := ReviewPROutput{
+		Findings:      domainFindingsToOutput(allFindings),
+		TotalFindings: len(allFindings),
+		BySeverity:    countBySeverity(allFindings),
+		ByCategory:    countByCategory(allFindings),
+		ReviewerStats: buildReviewerStats(result.Reviews),
+		TokensIn:      totalTokensIn,
+		TokensOut:     totalTokensOut,
+		Cost:          totalCost,
+	}
+
+	// Build summary
+	if len(allFindings) == 0 {
+		output.Summary = "No findings detected"
+		output.Message = "PR review complete: no issues found"
+	} else {
+		output.Summary = buildFindingsSummary(allFindings)
+		output.Message = fmt.Sprintf("PR review complete: %d findings", len(allFindings))
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: output.Message},
+		},
+	}, output, nil
+}
+
+// =============================================================================
+// post_findings Tool
+// =============================================================================
+
+// registerPostFindingsTool registers the post_findings tool.
+func (s *Server) registerPostFindingsTool() {
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "post_findings",
+		Description: `Post findings to a GitHub PR as inline review comments.
+
+This tool takes a list of findings (typically from review_pr or edit_finding) and posts them
+as a GitHub review with inline comments. Fingerprint-based deduplication prevents posting
+findings that already exist on the PR.
+
+Use this for:
+- Posting curated findings after filtering out false positives
+- Re-posting findings with updated severity/description
+- Posting findings in batches for large reviews`,
+	}, s.handlePostFindings)
+}
+
+func (s *Server) handlePostFindings(ctx context.Context, req *mcp.CallToolRequest, input PostFindingsInput) (*mcp.CallToolResult, PostFindingsOutput, error) {
+	// Validate inputs first (before checking dependencies)
+	if input.Owner == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "owner is required"},
+			},
+		}, PostFindingsOutput{}, nil
+	}
+	if input.Repo == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "repo is required"},
+			},
+		}, PostFindingsOutput{}, nil
+	}
+	if input.PRNumber <= 0 {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("invalid PR number: %d (must be positive)", input.PRNumber)},
+			},
+		}, PostFindingsOutput{}, nil
+	}
+	if len(input.Findings) == 0 {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "at least one finding is required"},
+			},
+		}, PostFindingsOutput{}, nil
+	}
+
+	// Validate severity for each finding
+	for i, f := range input.Findings {
+		if !isValidSeverity(f.Severity) {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("finding %d has invalid severity: %q. Valid values: %v", i, f.Severity, ValidSeverities)},
+				},
+			}, PostFindingsOutput{}, nil
+		}
+	}
+
+	// Check dependencies after validation
+	if s.deps.FindingPoster == nil {
+		return notImplementedResult("post_findings - FindingPoster not configured"), PostFindingsOutput{}, nil
+	}
+	if s.deps.RemoteGitHubClient == nil {
+		return notImplementedResult("post_findings - RemoteGitHubClient not configured"), PostFindingsOutput{}, nil
+	}
+
+	// Dry run mode - just validate and return what would be posted
+	if input.DryRun {
+		fingerprints := make([]string, len(input.Findings))
+		for i, f := range input.Findings {
+			fingerprints[i] = getFingerprintFromInput(f)
+		}
+		return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("Dry run: would post %d findings", len(input.Findings))},
+				},
+			}, PostFindingsOutput{
+				Success:            true,
+				Posted:             len(input.Findings),
+				ReviewAction:       determineReviewAction(nil, input.ReviewAction, input.BlockingFindings, nil),
+				PostedFingerprints: fingerprints,
+				Message:            fmt.Sprintf("Dry run: would post %d findings", len(input.Findings)),
+			}, nil
+	}
+
+	// Fetch PR metadata to get commit SHA
+	metadata, err := s.deps.RemoteGitHubClient.GetPRMetadata(ctx, input.Owner, input.Repo, input.PRNumber)
+	if err != nil {
+		return nil, PostFindingsOutput{}, fmt.Errorf("fetch PR metadata: %w", err)
+	}
+
+	// Fetch PR diff for line position calculation
+	diff, err := s.deps.RemoteGitHubClient.GetPRDiff(ctx, input.Owner, input.Repo, input.PRNumber)
+	if err != nil {
+		return nil, PostFindingsOutput{}, fmt.Errorf("fetch PR diff: %w", err)
+	}
+
+	// Convert findings to domain type
+	domainFindings := make([]domain.Finding, len(input.Findings))
+	for i, f := range input.Findings {
+		domainFindings[i] = findingInputToDomain(f)
+	}
+
+	// Build review from findings
+	domainReview := domain.Review{
+		Findings: domainFindings,
+		Summary:  buildFindingsSummary(domainFindings),
+	}
+
+	// Build fingerprints for blocking check (preserve original if provided)
+	inputFingerprints := make([]string, len(input.Findings))
+	for i, f := range input.Findings {
+		inputFingerprints[i] = getFingerprintFromInput(f)
+	}
+
+	// Determine review action using preserved fingerprints
+	reviewAction := determineReviewAction(domainFindings, input.ReviewAction, input.BlockingFindings, inputFingerprints)
+
+	// Build post request
+	postReq := review.GitHubPostRequest{
+		Owner:     input.Owner,
+		Repo:      input.Repo,
+		PRNumber:  input.PRNumber,
+		CommitSHA: metadata.HeadSHA,
+		Review:    domainReview,
+		Diff:      diff,
+	}
+
+	// Map review action to GitHub format
+	switch reviewAction {
+	case "REQUEST_CHANGES":
+		postReq.ActionOnCritical = "request_changes"
+		postReq.ActionOnHigh = "request_changes"
+	case "APPROVE":
+		postReq.ActionOnClean = "approve"
+	default:
+		postReq.ActionOnMedium = "comment"
+		postReq.ActionOnLow = "comment"
+	}
+
+	// Post the review
+	result, err := s.deps.FindingPoster.PostReview(ctx, postReq)
+	if err != nil {
+		return nil, PostFindingsOutput{}, fmt.Errorf("post review: %w", err)
+	}
+
+	// Reuse inputFingerprints computed earlier for blocking check
+	output := PostFindingsOutput{
+		Success:            true,
+		Posted:             result.CommentsPosted,
+		Skipped:            result.CommentsSkipped,
+		SkippedDuplicates:  result.DuplicatesSkipped,
+		ReviewID:           result.ReviewID,
+		ReviewAction:       reviewAction,
+		PostedFingerprints: inputFingerprints,
+		Message:            fmt.Sprintf("Posted %d findings to PR #%d", result.CommentsPosted, input.PRNumber),
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: output.Message},
+		},
+	}, output, nil
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// countBySeverity counts findings by severity level.
+func countBySeverity(findings []domain.Finding) map[string]int {
+	counts := make(map[string]int)
+	for _, f := range findings {
+		sev := f.Severity
+		if sev == "" {
+			sev = "unknown"
+		}
+		counts[sev]++
+	}
+	return counts
+}
+
+// countByCategory counts findings by category.
+func countByCategory(findings []domain.Finding) map[string]int {
+	counts := make(map[string]int)
+	for _, f := range findings {
+		cat := f.Category
+		if cat == "" {
+			cat = "unknown"
+		}
+		counts[cat]++
+	}
+	return counts
+}
+
+// buildReviewerStats builds per-reviewer statistics.
+func buildReviewerStats(reviews []domain.Review) []ReviewerStat {
+	stats := make(map[string]int)
+	for _, r := range reviews {
+		for _, f := range r.Findings {
+			name := f.ReviewerName
+			if name == "" {
+				name = r.ProviderName
+			}
+			stats[name]++
+		}
+	}
+
+	result := make([]ReviewerStat, 0, len(stats))
+	for name, count := range stats {
+		result = append(result, ReviewerStat{Name: name, Findings: count})
+	}
+	return result
+}
+
+// buildFindingsSummary builds a human-readable summary of findings.
+func buildFindingsSummary(findings []domain.Finding) string {
+	if len(findings) == 0 {
+		return "No findings detected"
+	}
+
+	counts := countBySeverity(findings)
+	var parts []string
+	for _, sev := range []string{"critical", "high", "medium", "low"} {
+		if c := counts[sev]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", c, sev))
+		}
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d findings", len(findings))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// determineReviewAction determines the GitHub review action based on findings.
+// findingFingerprints should be the preserved/computed fingerprints matching the findings slice.
+// If nil, fingerprints are computed from domain findings (for backward compatibility).
+func determineReviewAction(findings []domain.Finding, override *string, blockingFingerprints []string, findingFingerprints []string) string {
+	if override != nil && *override != "" {
+		return strings.ToUpper(*override)
+	}
+
+	// Check for blocking fingerprints
+	blockingSet := make(map[string]bool)
+	for _, fp := range blockingFingerprints {
+		blockingSet[fp] = true
+	}
+
+	hasBlocking := false
+	for i, f := range findings {
+		// Use provided fingerprint if available, otherwise compute
+		var fp string
+		if findingFingerprints != nil && i < len(findingFingerprints) {
+			fp = findingFingerprints[i]
+		} else {
+			fp = string(f.Fingerprint())
+		}
+
+		if blockingSet[fp] {
+			hasBlocking = true
+			break
+		}
+		if f.Severity == "critical" || f.Severity == "high" {
+			hasBlocking = true
+			break
+		}
+	}
+
+	if hasBlocking {
+		return "REQUEST_CHANGES"
+	}
+	if len(findings) > 0 {
+		return "COMMENT"
+	}
+	return "APPROVE"
+}
+
+// truncateFingerprint safely truncates a fingerprint for display purposes.
+// Returns at most maxLen characters, or the full string if shorter.
+func truncateFingerprint(fp string, maxLen int) string {
+	if len(fp) <= maxLen {
+		return fp
+	}
+	return fp[:maxLen]
+}

--- a/internal/adapter/mcp/review_handlers_test.go
+++ b/internal/adapter/mcp/review_handlers_test.go
@@ -1,0 +1,950 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bkyoung/code-reviewer/internal/domain"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mockPRReviewer is a test mock for PRReviewer interface.
+type mockPRReviewer struct {
+	result review.Result
+	err    error
+}
+
+func (m *mockPRReviewer) ReviewPR(ctx context.Context, req review.PRRequest) (review.Result, error) {
+	return m.result, m.err
+}
+
+// mockFindingPoster is a test mock for FindingPoster interface.
+type mockFindingPoster struct {
+	result *review.GitHubPostResult
+	err    error
+}
+
+func (m *mockFindingPoster) PostReview(ctx context.Context, req review.GitHubPostRequest) (*review.GitHubPostResult, error) {
+	return m.result, m.err
+}
+
+// mockPRMetadataFetcher is a test mock for PRMetadataFetcher interface.
+type mockPRMetadataFetcher struct {
+	metadata *domain.PRMetadata
+	diff     domain.Diff
+	metaErr  error
+	diffErr  error
+}
+
+func (m *mockPRMetadataFetcher) GetPRMetadata(ctx context.Context, owner, repo string, prNumber int) (*domain.PRMetadata, error) {
+	return m.metadata, m.metaErr
+}
+
+func (m *mockPRMetadataFetcher) GetPRDiff(ctx context.Context, owner, repo string, prNumber int) (domain.Diff, error) {
+	return m.diff, m.diffErr
+}
+
+func TestHandleEditFinding(t *testing.T) {
+	// Create a server with no dependencies (edit_finding is a pure function)
+	s := &Server{deps: ServerDeps{}}
+
+	baseFinding := FindingInput{
+		ID:          "original-id",
+		File:        "main.go",
+		LineStart:   10,
+		LineEnd:     15,
+		Severity:    "medium",
+		Category:    "security",
+		Description: "Original description",
+		Suggestion:  "Original suggestion",
+	}
+
+	t.Run("returns finding unchanged when no overrides provided", func(t *testing.T) {
+		input := EditFindingInput{
+			Finding: baseFinding,
+		}
+
+		result, output, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, baseFinding.File, output.Finding.File)
+		assert.Equal(t, baseFinding.LineStart, output.Finding.LineStart)
+		assert.Equal(t, baseFinding.LineEnd, output.Finding.LineEnd)
+		assert.Equal(t, baseFinding.Severity, output.Finding.Severity)
+		assert.Equal(t, baseFinding.Category, output.Finding.Category)
+		assert.Equal(t, baseFinding.Description, output.Finding.Description)
+		assert.Equal(t, baseFinding.Suggestion, output.Finding.Suggestion)
+	})
+
+	t.Run("overrides severity when provided", func(t *testing.T) {
+		newSeverity := "critical"
+		input := EditFindingInput{
+			Finding:  baseFinding,
+			Severity: &newSeverity,
+		}
+
+		result, output, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, "critical", output.Finding.Severity)
+		// Other fields unchanged
+		assert.Equal(t, baseFinding.File, output.Finding.File)
+		assert.Equal(t, baseFinding.Category, output.Finding.Category)
+		assert.Equal(t, baseFinding.Description, output.Finding.Description)
+	})
+
+	t.Run("overrides category when provided", func(t *testing.T) {
+		newCategory := "performance"
+		input := EditFindingInput{
+			Finding:  baseFinding,
+			Category: &newCategory,
+		}
+
+		result, output, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, "performance", output.Finding.Category)
+	})
+
+	t.Run("overrides description when provided", func(t *testing.T) {
+		newDescription := "Updated description with more detail"
+		input := EditFindingInput{
+			Finding:     baseFinding,
+			Description: &newDescription,
+		}
+
+		result, output, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, "Updated description with more detail", output.Finding.Description)
+	})
+
+	t.Run("overrides suggestion when provided", func(t *testing.T) {
+		newSuggestion := "Updated suggestion"
+		input := EditFindingInput{
+			Finding:    baseFinding,
+			Suggestion: &newSuggestion,
+		}
+
+		result, output, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, "Updated suggestion", output.Finding.Suggestion)
+	})
+
+	t.Run("overrides multiple fields at once", func(t *testing.T) {
+		newSeverity := "high"
+		newCategory := "bug"
+		newDescription := "This is a bug"
+		input := EditFindingInput{
+			Finding:     baseFinding,
+			Severity:    &newSeverity,
+			Category:    &newCategory,
+			Description: &newDescription,
+		}
+
+		result, output, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, "high", output.Finding.Severity)
+		assert.Equal(t, "bug", output.Finding.Category)
+		assert.Equal(t, "This is a bug", output.Finding.Description)
+		// Unchanged fields
+		assert.Equal(t, baseFinding.File, output.Finding.File)
+		assert.Equal(t, baseFinding.LineStart, output.Finding.LineStart)
+		assert.Equal(t, baseFinding.Suggestion, output.Finding.Suggestion)
+	})
+
+	t.Run("recalculates fingerprint when fingerprint-relevant field changes", func(t *testing.T) {
+		// Get original fingerprint
+		originalInput := EditFindingInput{Finding: baseFinding}
+		_, originalOutput, _ := s.handleEditFinding(context.Background(), nil, originalInput)
+		originalFingerprint := originalOutput.Finding.Fingerprint
+
+		// Change severity (fingerprint-relevant)
+		newSeverity := "critical"
+		changedInput := EditFindingInput{
+			Finding:  baseFinding,
+			Severity: &newSeverity,
+		}
+		_, changedOutput, _ := s.handleEditFinding(context.Background(), nil, changedInput)
+
+		// Fingerprint should be different
+		assert.NotEqual(t, originalFingerprint, changedOutput.Finding.Fingerprint)
+	})
+
+	t.Run("fingerprint unchanged when only suggestion changes", func(t *testing.T) {
+		// Get original fingerprint
+		originalInput := EditFindingInput{Finding: baseFinding}
+		_, originalOutput, _ := s.handleEditFinding(context.Background(), nil, originalInput)
+		originalFingerprint := originalOutput.Finding.Fingerprint
+
+		// Change suggestion (NOT fingerprint-relevant)
+		newSuggestion := "Totally different suggestion"
+		changedInput := EditFindingInput{
+			Finding:    baseFinding,
+			Suggestion: &newSuggestion,
+		}
+		_, changedOutput, _ := s.handleEditFinding(context.Background(), nil, changedInput)
+
+		// Fingerprint should be same (suggestion is not part of fingerprint)
+		assert.Equal(t, originalFingerprint, changedOutput.Finding.Fingerprint)
+	})
+
+	t.Run("result message indicates what was changed", func(t *testing.T) {
+		newSeverity := "low"
+		input := EditFindingInput{
+			Finding:  baseFinding,
+			Severity: &newSeverity,
+		}
+
+		result, _, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Check that result has text content
+		require.Len(t, result.Content, 1)
+		textContent, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "severity")
+	})
+
+	t.Run("validates severity value", func(t *testing.T) {
+		invalidSeverity := "extreme" // not a valid severity
+		input := EditFindingInput{
+			Finding:  baseFinding,
+			Severity: &invalidSeverity,
+		}
+
+		result, _, err := s.handleEditFinding(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestFindingInputToDomain(t *testing.T) {
+	input := FindingInput{
+		ID:           "test-id",
+		File:         "pkg/handler.go",
+		LineStart:    100,
+		LineEnd:      105,
+		Severity:     "high",
+		Category:     "security",
+		Description:  "SQL injection vulnerability",
+		Suggestion:   "Use parameterized queries",
+		ReviewerName: "security-bot",
+	}
+
+	finding := findingInputToDomain(input)
+
+	assert.Equal(t, input.ID, finding.ID)
+	assert.Equal(t, input.File, finding.File)
+	assert.Equal(t, input.LineStart, finding.LineStart)
+	assert.Equal(t, input.LineEnd, finding.LineEnd)
+	assert.Equal(t, input.Severity, finding.Severity)
+	assert.Equal(t, input.Category, finding.Category)
+	assert.Equal(t, input.Description, finding.Description)
+	assert.Equal(t, input.Suggestion, finding.Suggestion)
+	assert.Equal(t, input.ReviewerName, finding.ReviewerName)
+}
+
+func TestDomainFindingToOutput(t *testing.T) {
+	finding := domain.Finding{
+		ID:             "abc123",
+		File:           "main.go",
+		LineStart:      10,
+		LineEnd:        20,
+		Severity:       "medium",
+		Category:       "bug",
+		Description:    "Potential nil pointer",
+		Suggestion:     "Add nil check",
+		ReviewerName:   "arch-reviewer",
+		ReviewerWeight: 1.5,
+	}
+
+	output := domainFindingToOutput(finding)
+
+	assert.Equal(t, finding.ID, output.ID)
+	assert.Equal(t, finding.File, output.File)
+	assert.Equal(t, finding.LineStart, output.LineStart)
+	assert.Equal(t, finding.LineEnd, output.LineEnd)
+	assert.Equal(t, finding.Severity, output.Severity)
+	assert.Equal(t, finding.Category, output.Category)
+	assert.Equal(t, finding.Description, output.Description)
+	assert.Equal(t, finding.Suggestion, output.Suggestion)
+	assert.Equal(t, finding.ReviewerName, output.ReviewerName)
+	assert.Equal(t, finding.ReviewerWeight, output.ReviewerWeight)
+	// Fingerprint should be calculated
+	assert.NotEmpty(t, output.Fingerprint)
+	assert.Equal(t, string(finding.Fingerprint()), output.Fingerprint)
+}
+
+func TestHandleReviewPR(t *testing.T) {
+	t.Run("returns not implemented when PRReviewer is nil", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{}}
+
+		input := ReviewPRInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+		}
+
+		result, output, err := s.handleReviewPR(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		assert.Empty(t, output.Findings)
+	})
+
+	t.Run("validates required inputs", func(t *testing.T) {
+		mock := &mockPRReviewer{}
+		s := &Server{deps: ServerDeps{PRReviewer: mock}}
+
+		testCases := []struct {
+			name  string
+			input ReviewPRInput
+			want  string
+		}{
+			{
+				name:  "missing owner",
+				input: ReviewPRInput{Repo: "repo", PRNumber: 123},
+				want:  "owner is required",
+			},
+			{
+				name:  "missing repo",
+				input: ReviewPRInput{Owner: "owner", PRNumber: 123},
+				want:  "repo is required",
+			},
+			{
+				name:  "invalid PR number",
+				input: ReviewPRInput{Owner: "owner", Repo: "repo", PRNumber: 0},
+				want:  "invalid PR number",
+			},
+			{
+				name:  "negative PR number",
+				input: ReviewPRInput{Owner: "owner", Repo: "repo", PRNumber: -1},
+				want:  "invalid PR number",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result, _, err := s.handleReviewPR(context.Background(), nil, tc.input)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.True(t, result.IsError)
+				textContent, ok := result.Content[0].(*mcp.TextContent)
+				require.True(t, ok)
+				assert.Contains(t, textContent.Text, tc.want)
+			})
+		}
+	})
+
+	t.Run("returns findings from review", func(t *testing.T) {
+		mock := &mockPRReviewer{
+			result: review.Result{
+				Reviews: []domain.Review{
+					{
+						ProviderName: "anthropic",
+						ModelName:    "claude-sonnet-4-5",
+						TokensIn:     1000,
+						TokensOut:    500,
+						Cost:         0.01,
+						Findings: []domain.Finding{
+							{
+								ID:          "f1",
+								File:        "main.go",
+								LineStart:   10,
+								LineEnd:     15,
+								Severity:    "high",
+								Category:    "security",
+								Description: "SQL injection vulnerability",
+							},
+							{
+								ID:          "f2",
+								File:        "utils.go",
+								LineStart:   20,
+								LineEnd:     25,
+								Severity:    "medium",
+								Category:    "bug",
+								Description: "Nil pointer dereference",
+							},
+						},
+					},
+				},
+			},
+		}
+		s := &Server{deps: ServerDeps{PRReviewer: mock}}
+
+		input := ReviewPRInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+		}
+
+		result, output, err := s.handleReviewPR(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.Equal(t, 2, output.TotalFindings)
+		assert.Len(t, output.Findings, 2)
+		assert.Equal(t, 1, output.BySeverity["high"])
+		assert.Equal(t, 1, output.BySeverity["medium"])
+		assert.Equal(t, 1, output.ByCategory["security"])
+		assert.Equal(t, 1, output.ByCategory["bug"])
+		assert.Equal(t, 1000, output.TokensIn)
+		assert.Equal(t, 500, output.TokensOut)
+		assert.Equal(t, 0.01, output.Cost)
+	})
+
+	t.Run("aggregates findings from multiple reviews", func(t *testing.T) {
+		mock := &mockPRReviewer{
+			result: review.Result{
+				Reviews: []domain.Review{
+					{
+						ProviderName: "security",
+						TokensIn:     500,
+						TokensOut:    200,
+						Cost:         0.005,
+						Findings: []domain.Finding{
+							{ID: "f1", Severity: "high", Category: "security"},
+						},
+					},
+					{
+						ProviderName: "architecture",
+						TokensIn:     600,
+						TokensOut:    300,
+						Cost:         0.006,
+						Findings: []domain.Finding{
+							{ID: "f2", Severity: "medium", Category: "architecture"},
+							{ID: "f3", Severity: "low", Category: "maintainability"},
+						},
+					},
+				},
+			},
+		}
+		s := &Server{deps: ServerDeps{PRReviewer: mock}}
+
+		input := ReviewPRInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+		}
+
+		result, output, err := s.handleReviewPR(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Equal(t, 3, output.TotalFindings)
+		assert.Equal(t, 1100, output.TokensIn)
+		assert.Equal(t, 500, output.TokensOut)
+		assert.InDelta(t, 0.011, output.Cost, 0.0001)
+	})
+
+	t.Run("handles no findings", func(t *testing.T) {
+		mock := &mockPRReviewer{
+			result: review.Result{
+				Reviews: []domain.Review{
+					{ProviderName: "security", Findings: []domain.Finding{}},
+				},
+			},
+		}
+		s := &Server{deps: ServerDeps{PRReviewer: mock}}
+
+		input := ReviewPRInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+		}
+
+		result, output, err := s.handleReviewPR(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Equal(t, 0, output.TotalFindings)
+		assert.Contains(t, output.Message, "no issues found")
+	})
+
+	t.Run("propagates review errors", func(t *testing.T) {
+		mock := &mockPRReviewer{
+			err: errors.New("GitHub API rate limit exceeded"),
+		}
+		s := &Server{deps: ServerDeps{PRReviewer: mock}}
+
+		input := ReviewPRInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+		}
+
+		_, _, err := s.handleReviewPR(context.Background(), nil, input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GitHub API rate limit exceeded")
+	})
+}
+
+func TestHandlePostFindings(t *testing.T) {
+	t.Run("returns not implemented when FindingPoster is nil", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{{File: "main.go", Severity: "high"}},
+		}
+
+		result, output, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		assert.False(t, output.Success)
+	})
+
+	t.Run("returns not implemented when RemoteGitHubClient is nil", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{
+			FindingPoster: &mockFindingPoster{},
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{{File: "main.go", Severity: "high"}},
+		}
+
+		result, output, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		assert.False(t, output.Success)
+	})
+
+	t.Run("validates required inputs", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{FindingPoster: nil}} // Even with nil, validation runs first
+
+		testCases := []struct {
+			name  string
+			input PostFindingsInput
+			want  string
+		}{
+			{
+				name: "missing owner",
+				input: PostFindingsInput{
+					Repo:     "repo",
+					PRNumber: 123,
+					Findings: []FindingInput{{File: "main.go"}},
+				},
+				want: "owner is required",
+			},
+			{
+				name: "missing repo",
+				input: PostFindingsInput{
+					Owner:    "owner",
+					PRNumber: 123,
+					Findings: []FindingInput{{File: "main.go"}},
+				},
+				want: "repo is required",
+			},
+			{
+				name: "invalid PR number",
+				input: PostFindingsInput{
+					Owner:    "owner",
+					Repo:     "repo",
+					PRNumber: 0,
+					Findings: []FindingInput{{File: "main.go"}},
+				},
+				want: "invalid PR number",
+			},
+			{
+				name: "no findings",
+				input: PostFindingsInput{
+					Owner:    "owner",
+					Repo:     "repo",
+					PRNumber: 123,
+					Findings: []FindingInput{},
+				},
+				want: "at least one finding is required",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result, _, err := s.handlePostFindings(context.Background(), nil, tc.input)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.True(t, result.IsError)
+				textContent, ok := result.Content[0].(*mcp.TextContent)
+				require.True(t, ok)
+				assert.Contains(t, textContent.Text, tc.want)
+			})
+		}
+	})
+
+	t.Run("dry run returns what would be posted", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      &mockFindingPoster{},
+			RemoteGitHubClient: &mockPRMetadataFetcher{},
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{
+				{File: "main.go", LineStart: 10, Severity: "high", Category: "security", Description: "SQL injection"},
+				{File: "utils.go", LineStart: 20, Severity: "medium", Category: "bug", Description: "Nil pointer"},
+			},
+			DryRun: true,
+		}
+
+		result, output, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.True(t, output.Success)
+		assert.Equal(t, 2, output.Posted)
+		assert.Len(t, output.PostedFingerprints, 2)
+		assert.Contains(t, output.Message, "Dry run")
+	})
+
+	t.Run("posts findings successfully", func(t *testing.T) {
+		mockPoster := &mockFindingPoster{
+			result: &review.GitHubPostResult{
+				ReviewID:        12345,
+				CommentsPosted:  2,
+				CommentsSkipped: 0,
+			},
+		}
+		mockFetcher := &mockPRMetadataFetcher{
+			metadata: &domain.PRMetadata{
+				HeadSHA: "abc123",
+				BaseRef: "main",
+				HeadRef: "feature",
+			},
+			diff: domain.Diff{
+				Files: []domain.FileDiff{{Path: "main.go"}},
+			},
+		}
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      mockPoster,
+			RemoteGitHubClient: mockFetcher,
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{
+				{File: "main.go", LineStart: 10, Severity: "high", Category: "security", Description: "Issue 1"},
+				{File: "utils.go", LineStart: 20, Severity: "medium", Category: "bug", Description: "Issue 2"},
+			},
+		}
+
+		result, output, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.True(t, output.Success)
+		assert.Equal(t, 2, output.Posted)
+		assert.Equal(t, int64(12345), output.ReviewID)
+		assert.Equal(t, "REQUEST_CHANGES", output.ReviewAction)
+		assert.Len(t, output.PostedFingerprints, 2)
+	})
+
+	t.Run("propagates metadata fetch errors", func(t *testing.T) {
+		mockFetcher := &mockPRMetadataFetcher{
+			metaErr: errors.New("rate limit exceeded"),
+		}
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      &mockFindingPoster{},
+			RemoteGitHubClient: mockFetcher,
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{{File: "main.go", Severity: "high"}},
+		}
+
+		_, _, err := s.handlePostFindings(context.Background(), nil, input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rate limit exceeded")
+	})
+
+	t.Run("propagates diff fetch errors", func(t *testing.T) {
+		mockFetcher := &mockPRMetadataFetcher{
+			metadata: &domain.PRMetadata{HeadSHA: "abc123"},
+			diffErr:  errors.New("diff too large"),
+		}
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      &mockFindingPoster{},
+			RemoteGitHubClient: mockFetcher,
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{{File: "main.go", Severity: "high"}},
+		}
+
+		_, _, err := s.handlePostFindings(context.Background(), nil, input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "diff too large")
+	})
+
+	t.Run("propagates post errors", func(t *testing.T) {
+		mockPoster := &mockFindingPoster{
+			err: errors.New("permission denied"),
+		}
+		mockFetcher := &mockPRMetadataFetcher{
+			metadata: &domain.PRMetadata{HeadSHA: "abc123"},
+			diff:     domain.Diff{},
+		}
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      mockPoster,
+			RemoteGitHubClient: mockFetcher,
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{{File: "main.go", Severity: "high"}},
+		}
+
+		_, _, err := s.handlePostFindings(context.Background(), nil, input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "permission denied")
+	})
+
+	t.Run("validates severity for each finding", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      &mockFindingPoster{},
+			RemoteGitHubClient: &mockPRMetadataFetcher{},
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{
+				{File: "main.go", Severity: "high", Category: "security", Description: "Valid"},
+				{File: "utils.go", Severity: "invalid-severity", Category: "bug", Description: "Invalid"},
+			},
+		}
+
+		result, _, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		textContent, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "finding 1 has invalid severity")
+		assert.Contains(t, textContent.Text, "invalid-severity")
+	})
+
+	t.Run("preserves fingerprint from input", func(t *testing.T) {
+		mockPoster := &mockFindingPoster{
+			result: &review.GitHubPostResult{
+				ReviewID:       12345,
+				CommentsPosted: 1,
+			},
+		}
+		mockFetcher := &mockPRMetadataFetcher{
+			metadata: &domain.PRMetadata{HeadSHA: "abc123"},
+			diff:     domain.Diff{},
+		}
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      mockPoster,
+			RemoteGitHubClient: mockFetcher,
+		}}
+
+		// Use a preserved fingerprint from review_pr output
+		preservedFingerprint := "abc123def456preserved"
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{
+				{
+					Fingerprint: preservedFingerprint,
+					File:        "main.go",
+					LineStart:   10,
+					Severity:    "high",
+					Category:    "security",
+					Description: "Test issue",
+				},
+			},
+		}
+
+		result, output, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		assert.True(t, output.Success)
+		require.Len(t, output.PostedFingerprints, 1)
+		assert.Equal(t, preservedFingerprint, output.PostedFingerprints[0], "fingerprint should be preserved from input")
+	})
+
+	t.Run("computes fingerprint when not provided", func(t *testing.T) {
+		s := &Server{deps: ServerDeps{
+			FindingPoster:      &mockFindingPoster{},
+			RemoteGitHubClient: &mockPRMetadataFetcher{},
+		}}
+
+		input := PostFindingsInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+			Findings: []FindingInput{
+				{
+					// No fingerprint provided
+					File:        "main.go",
+					LineStart:   10,
+					Severity:    "high",
+					Category:    "security",
+					Description: "Test issue",
+				},
+			},
+			DryRun: true,
+		}
+
+		result, output, err := s.handlePostFindings(context.Background(), nil, input)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+
+		require.Len(t, output.PostedFingerprints, 1)
+		assert.NotEmpty(t, output.PostedFingerprints[0], "fingerprint should be computed when not provided")
+		// Computed fingerprints are MD5 hex, should be 32 chars
+		assert.Len(t, output.PostedFingerprints[0], 32)
+	})
+}
+
+func TestCountBySeverity(t *testing.T) {
+	findings := []domain.Finding{
+		{Severity: "high"},
+		{Severity: "high"},
+		{Severity: "medium"},
+		{Severity: "low"},
+		{Severity: ""},
+	}
+
+	counts := countBySeverity(findings)
+
+	assert.Equal(t, 2, counts["high"])
+	assert.Equal(t, 1, counts["medium"])
+	assert.Equal(t, 1, counts["low"])
+	assert.Equal(t, 1, counts["unknown"])
+}
+
+func TestBuildFindingsSummary(t *testing.T) {
+	t.Run("empty findings", func(t *testing.T) {
+		summary := buildFindingsSummary([]domain.Finding{})
+		assert.Equal(t, "No findings detected", summary)
+	})
+
+	t.Run("single severity", func(t *testing.T) {
+		findings := []domain.Finding{
+			{Severity: "high"},
+			{Severity: "high"},
+		}
+		summary := buildFindingsSummary(findings)
+		assert.Equal(t, "2 high", summary)
+	})
+
+	t.Run("multiple severities", func(t *testing.T) {
+		findings := []domain.Finding{
+			{Severity: "critical"},
+			{Severity: "high"},
+			{Severity: "high"},
+			{Severity: "medium"},
+		}
+		summary := buildFindingsSummary(findings)
+		assert.Equal(t, "1 critical, 2 high, 1 medium", summary)
+	})
+}
+
+func TestDetermineReviewAction(t *testing.T) {
+	t.Run("uses override when provided", func(t *testing.T) {
+		override := "comment"
+		action := determineReviewAction(
+			[]domain.Finding{{Severity: "critical"}},
+			&override,
+			nil,
+			nil,
+		)
+		assert.Equal(t, "COMMENT", action)
+	})
+
+	t.Run("returns REQUEST_CHANGES for critical findings", func(t *testing.T) {
+		action := determineReviewAction(
+			[]domain.Finding{{Severity: "critical"}},
+			nil,
+			nil,
+			nil,
+		)
+		assert.Equal(t, "REQUEST_CHANGES", action)
+	})
+
+	t.Run("returns REQUEST_CHANGES for high findings", func(t *testing.T) {
+		action := determineReviewAction(
+			[]domain.Finding{{Severity: "high"}},
+			nil,
+			nil,
+			nil,
+		)
+		assert.Equal(t, "REQUEST_CHANGES", action)
+	})
+
+	t.Run("returns COMMENT for medium/low findings", func(t *testing.T) {
+		action := determineReviewAction(
+			[]domain.Finding{{Severity: "medium"}},
+			nil,
+			nil,
+			nil,
+		)
+		assert.Equal(t, "COMMENT", action)
+	})
+
+	t.Run("returns APPROVE when no findings", func(t *testing.T) {
+		action := determineReviewAction([]domain.Finding{}, nil, nil, nil)
+		assert.Equal(t, "APPROVE", action)
+	})
+
+	t.Run("uses preserved fingerprints for blocking check", func(t *testing.T) {
+		preservedFP := "preserved-fingerprint-123"
+		action := determineReviewAction(
+			[]domain.Finding{{Severity: "low", File: "test.go"}}, // low severity normally returns COMMENT
+			nil,
+			[]string{preservedFP}, // blocking fingerprint
+			[]string{preservedFP}, // preserved fingerprint matches blocking
+		)
+		assert.Equal(t, "REQUEST_CHANGES", action, "should REQUEST_CHANGES when preserved fingerprint matches blocking")
+	})
+}

--- a/internal/adapter/mcp/review_types.go
+++ b/internal/adapter/mcp/review_types.go
@@ -1,0 +1,149 @@
+package mcp
+
+// =============================================================================
+// Review Tool Types (Phase 3.5d - MCP Review Tools)
+// =============================================================================
+
+// FindingInput represents a finding in MCP tool input.
+// This mirrors domain.Finding but uses MCP-friendly field names and tags.
+type FindingInput struct {
+	ID             string  `json:"id,omitempty"`
+	Fingerprint    string  `json:"fingerprint,omitempty" jsonschema:"Original fingerprint (preserves identity when passing between tools)"`
+	File           string  `json:"file" jsonschema:"File path where the finding occurs"`
+	LineStart      int     `json:"line_start" jsonschema:"Starting line number (1-based)"`
+	LineEnd        int     `json:"line_end" jsonschema:"Ending line number (1-based)"`
+	Severity       string  `json:"severity" jsonschema:"Severity level (critical, high, medium, low)"`
+	Category       string  `json:"category" jsonschema:"Finding category (security, bug, maintainability, etc.)"`
+	Description    string  `json:"description" jsonschema:"Description of the issue"`
+	Suggestion     string  `json:"suggestion,omitempty" jsonschema:"Suggested fix or remediation"`
+	ReviewerName   string  `json:"reviewer_name,omitempty" jsonschema:"Name of the reviewer that found this issue"`
+	ReviewerWeight float64 `json:"reviewer_weight,omitempty" jsonschema:"Weight of the reviewer (for merge prioritization)"`
+}
+
+// FindingOutput represents a finding in MCP tool output.
+// Includes the fingerprint for deduplication.
+type FindingOutput struct {
+	ID             string  `json:"id"`
+	Fingerprint    string  `json:"fingerprint"`
+	File           string  `json:"file"`
+	LineStart      int     `json:"line_start"`
+	LineEnd        int     `json:"line_end"`
+	Severity       string  `json:"severity"`
+	Category       string  `json:"category"`
+	Description    string  `json:"description"`
+	Suggestion     string  `json:"suggestion,omitempty"`
+	ReviewerName   string  `json:"reviewer_name,omitempty"`
+	ReviewerWeight float64 `json:"reviewer_weight,omitempty"`
+}
+
+// =============================================================================
+// edit_finding Tool Types
+// =============================================================================
+
+// EditFindingInput is the input for the edit_finding tool.
+type EditFindingInput struct {
+	Finding     FindingInput `json:"finding" jsonschema:"The finding to edit"`
+	Severity    *string      `json:"severity,omitempty" jsonschema:"New severity (critical, high, medium, low)"`
+	Category    *string      `json:"category,omitempty" jsonschema:"New category"`
+	Description *string      `json:"description,omitempty" jsonschema:"New description"`
+	Suggestion  *string      `json:"suggestion,omitempty" jsonschema:"New suggestion"`
+}
+
+// EditFindingOutput is the output for the edit_finding tool.
+type EditFindingOutput struct {
+	Finding        FindingOutput `json:"finding"`
+	FieldsModified []string      `json:"fields_modified"`
+	Message        string        `json:"message"`
+}
+
+// =============================================================================
+// review_pr Tool Types
+// =============================================================================
+
+// ReviewPRInput is the input for the review_pr tool.
+type ReviewPRInput struct {
+	Owner     string   `json:"owner" jsonschema:"Repository owner"`
+	Repo      string   `json:"repo" jsonschema:"Repository name"`
+	PRNumber  int      `json:"pr_number" jsonschema:"Pull request number"`
+	Reviewers []string `json:"reviewers,omitempty" jsonschema:"Specific reviewers to use (defaults to cr.yaml configuration)"`
+}
+
+// ReviewPROutput is the output for the review_pr tool.
+type ReviewPROutput struct {
+	Findings      []FindingOutput   `json:"findings"`
+	Summary       string            `json:"summary"`
+	TotalFindings int               `json:"total_findings"`
+	BySeverity    map[string]int    `json:"by_severity"`
+	ByCategory    map[string]int    `json:"by_category"`
+	ReviewerStats []ReviewerStat    `json:"reviewer_stats,omitempty"`
+	TokensIn      int               `json:"tokens_in"`
+	TokensOut     int               `json:"tokens_out"`
+	Cost          float64           `json:"cost"`
+	Message       string            `json:"message"`
+	Metadata      *ReviewPRMetadata `json:"metadata,omitempty"`
+}
+
+// ReviewerStat captures per-reviewer statistics.
+type ReviewerStat struct {
+	Name     string `json:"name"`
+	Findings int    `json:"findings"`
+}
+
+// ReviewPRMetadata captures PR metadata for context.
+type ReviewPRMetadata struct {
+	Title      string   `json:"title"`
+	Author     string   `json:"author"`
+	BaseRef    string   `json:"base_ref"`
+	HeadRef    string   `json:"head_ref"`
+	HeadSHA    string   `json:"head_sha"`
+	FilesCount int      `json:"files_count"`
+	Additions  int      `json:"additions"`
+	Deletions  int      `json:"deletions"`
+	Labels     []string `json:"labels,omitempty"`
+}
+
+// =============================================================================
+// post_findings Tool Types
+// =============================================================================
+
+// PostFindingsInput is the input for the post_findings tool.
+type PostFindingsInput struct {
+	Owner            string         `json:"owner" jsonschema:"Repository owner"`
+	Repo             string         `json:"repo" jsonschema:"Repository name"`
+	PRNumber         int            `json:"pr_number" jsonschema:"Pull request number"`
+	Findings         []FindingInput `json:"findings" jsonschema:"Findings to post as review comments"`
+	SkipDuplicates   bool           `json:"skip_duplicates,omitempty" jsonschema:"Skip findings that already exist (based on fingerprint)"`
+	DryRun           bool           `json:"dry_run,omitempty" jsonschema:"Show what would be posted without actually posting"`
+	ReviewAction     *string        `json:"review_action,omitempty" jsonschema:"GitHub review action (COMMENT, REQUEST_CHANGES, APPROVE). Defaults based on severity."`
+	IncludeSummary   bool           `json:"include_summary,omitempty" jsonschema:"Include a summary comment at the end of the review"`
+	BlockingFindings []string       `json:"blocking_findings,omitempty" jsonschema:"Fingerprints of findings that should block the PR"`
+}
+
+// PostFindingsOutput is the output for the post_findings tool.
+type PostFindingsOutput struct {
+	Success            bool     `json:"success"`
+	Posted             int      `json:"posted"`
+	Skipped            int      `json:"skipped"`
+	SkippedDuplicates  int      `json:"skipped_duplicates"`
+	ReviewID           int64    `json:"review_id,omitempty"`
+	ReviewAction       string   `json:"review_action"`
+	PostedFingerprints []string `json:"posted_fingerprints,omitempty"`
+	Message            string   `json:"message"`
+}
+
+// =============================================================================
+// Severity and Category Constants
+// =============================================================================
+
+// ValidSeverities contains the valid severity levels.
+var ValidSeverities = []string{"critical", "high", "medium", "low"}
+
+// isValidSeverity checks if a severity is valid.
+func isValidSeverity(severity string) bool {
+	for _, s := range ValidSeverities {
+		if severity == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapter/mcp/server.go
+++ b/internal/adapter/mcp/server.go
@@ -3,9 +3,29 @@ package mcp
 import (
 	"context"
 
+	"github.com/bkyoung/code-reviewer/internal/domain"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
 	"github.com/bkyoung/code-reviewer/internal/usecase/triage"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// PRReviewer defines the interface for invoking code reviews on GitHub PRs.
+// This is implemented by review.Orchestrator.
+type PRReviewer interface {
+	ReviewPR(ctx context.Context, req review.PRRequest) (review.Result, error)
+}
+
+// FindingPoster defines the interface for posting findings to GitHub PRs.
+// This is implemented by github.Poster.
+type FindingPoster interface {
+	PostReview(ctx context.Context, req review.GitHubPostRequest) (*review.GitHubPostResult, error)
+}
+
+// PRMetadataFetcher fetches PR metadata for the post_findings tool.
+type PRMetadataFetcher interface {
+	GetPRMetadata(ctx context.Context, owner, repo string, prNumber int) (*domain.PRMetadata, error)
+	GetPRDiff(ctx context.Context, owner, repo string, prNumber int) (domain.Diff, error)
+}
 
 const (
 	// ServerName is the name reported to MCP clients.
@@ -22,6 +42,18 @@ type ServerDeps struct {
 
 	// TriageService is the session-based service (deprecated, for M3 write ops).
 	TriageService triage.TriageService
+
+	// PRReviewer invokes code reviews on GitHub PRs.
+	// Optional: only required for review_pr tool.
+	PRReviewer PRReviewer
+
+	// FindingPoster posts findings to GitHub PRs.
+	// Optional: only required for post_findings tool.
+	FindingPoster FindingPoster
+
+	// RemoteGitHubClient fetches PR metadata and diffs.
+	// Optional: only required for post_findings tool.
+	RemoteGitHubClient PRMetadataFetcher
 }
 
 // Server wraps the MCP server and provides triage tools.
@@ -73,6 +105,11 @@ func (s *Server) registerTools() {
 	s.registerPostCommentTool()
 	s.registerMarkResolvedTool()
 	s.registerRequestRereviewTool()
+
+	// Phase 3.5d Review tools
+	s.registerEditFindingTool()
+	s.registerReviewPRTool()
+	s.registerPostFindingsTool()
 }
 
 // Tool input/output types for M2 PR-based tools.


### PR DESCRIPTION
## Summary

Implements Issue #177 (Phase 3.5d: MCP Review Tools) - extending the code-reviewer MCP server with tools for AI-assisted code review workflow.

### New Tools

- **`edit_finding`**: Pure function to modify finding properties (severity, category, description, suggestion) and recalculate fingerprint. Enables filtering/adjusting findings before posting.

- **`review_pr`**: Invoke code reviewers on a GitHub PR and return findings WITHOUT posting. Supports per-reviewer aggregation, cost tracking, and custom reviewer selection.

- **`post_findings`**: Post curated findings to GitHub PR with fingerprint-based deduplication. (Stub implementation - requires additional wiring for full functionality)

### Design Decisions

1. **Interface Segregation**: Defined `PRReviewer` and `FindingPoster` interfaces for testability
2. **Validation-First**: Input validation runs before dependency checks for better error messages
3. **Graceful Degradation**: Tools return "not implemented" when dependencies aren't wired
4. **TDD**: All handlers have comprehensive test coverage

### Deferred

- `review_branch` tool (local git review) - tracked in Issue #181 (Phase 3.5d.2)
- Full `post_findings` wiring (needs `PRMetadataFetcher` for commit SHA/diff)

## Test plan

- [x] All existing tests pass (`mage test`)
- [x] Race detector passes (`mage testRace`)
- [x] Linting passes (`mage lint`)
- [x] Build succeeds (`mage buildAll`)
- [x] New tests cover:
  - `edit_finding`: property overrides, fingerprint recalculation, severity validation
  - `review_pr`: input validation, finding aggregation, error propagation
  - `post_findings`: input validation, stub behavior
  - Helper functions: `countBySeverity`, `buildFindingsSummary`, `determineReviewAction`

## Files Changed

- `internal/adapter/mcp/server.go` - Interface definitions, ServerDeps extension, tool registration
- `internal/adapter/mcp/review_types.go` - Input/output types for new tools
- `internal/adapter/mcp/review_handlers.go` - Handler implementations
- `internal/adapter/mcp/review_handlers_test.go` - Comprehensive test coverage

Closes #177