### PR TITLE
fix: preserve actual reply rationale in prior findings prompt

### DIFF
--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -534,14 +534,22 @@ func extractBotFingerprints(comments []github.PullRequestComment, botUsername st
 	return fingerprints
 }
 
-// analyzeFindingStatuses analyzes bot comments and their replies to determine
-// the status of each existing finding (Issue #108).
-// Returns a map of fingerprint → status and counts for each status.
-func analyzeFindingStatuses(
+// FindingStatusInfo contains the status and rationale for a finding.
+// The rationale is the actual reply body that determined the status,
+// which provides context for why a finding was acknowledged or disputed.
+type FindingStatusInfo struct {
+	Status    domain.FindingStatus
+	Rationale string // The reply body that determined the status
+}
+
+// analyzeFindingStatusInfo analyzes bot comments and their replies to determine
+// the status and rationale for each existing finding.
+// Returns a map of fingerprint → status info (including reply body) and counts.
+func analyzeFindingStatusInfo(
 	comments []github.PullRequestComment,
 	botUsername string,
-) (map[domain.FindingFingerprint]domain.FindingStatus, StatusCounts) {
-	statuses := make(map[domain.FindingFingerprint]domain.FindingStatus)
+) (map[domain.FindingFingerprint]FindingStatusInfo, StatusCounts) {
+	statusInfo := make(map[domain.FindingFingerprint]FindingStatusInfo)
 	var counts StatusCounts
 
 	// Group comments by parent to get reply chains
@@ -554,15 +562,32 @@ func analyzeFindingStatuses(
 			continue // Skip comments without fingerprints (legacy)
 		}
 
-		// Collect reply texts
+		// Collect reply texts and find the determining reply
 		var replyTexts []string
+		var determiningReply string
 		for _, reply := range group.Replies {
 			replyTexts = append(replyTexts, reply.Body)
 		}
 
 		// Detect status from replies
 		status := domain.DetectStatusFromReplies(replyTexts)
-		statuses[fp] = status
+
+		// Find the reply that determined the status (first match)
+		// This mirrors the logic in DetectStatusFromReplies
+		if status != domain.StatusOpen {
+			for _, reply := range group.Replies {
+				replyStatus := domain.DetectStatusFromText(reply.Body)
+				if replyStatus == status {
+					determiningReply = reply.Body
+					break
+				}
+			}
+		}
+
+		statusInfo[fp] = FindingStatusInfo{
+			Status:    status,
+			Rationale: determiningReply,
+		}
 
 		// Update counts
 		switch status {
@@ -573,6 +598,24 @@ func analyzeFindingStatuses(
 		case domain.StatusOpen:
 			counts.Open++
 		}
+	}
+
+	return statusInfo, counts
+}
+
+// analyzeFindingStatuses analyzes bot comments and their replies to determine
+// the status of each existing finding (Issue #108).
+// Returns a map of fingerprint → status and counts for each status.
+func analyzeFindingStatuses(
+	comments []github.PullRequestComment,
+	botUsername string,
+) (map[domain.FindingFingerprint]domain.FindingStatus, StatusCounts) {
+	// Delegate to the richer function and extract just the status
+	statusInfo, counts := analyzeFindingStatusInfo(comments, botUsername)
+
+	statuses := make(map[domain.FindingFingerprint]domain.FindingStatus, len(statusInfo))
+	for fp, info := range statusInfo {
+		statuses[fp] = info.Status
 	}
 
 	return statuses, counts

--- a/internal/usecase/github/triage_fetcher.go
+++ b/internal/usecase/github/triage_fetcher.go
@@ -55,14 +55,14 @@ func (f *TriageContextFetcher) FetchTriagedFindings(
 		return nil
 	}
 
-	// Analyze triage statuses using existing logic from poster.go
-	statuses, _ := analyzeFindingStatuses(comments, f.botUsername)
-	if len(statuses) == 0 {
+	// Analyze triage statuses with rationale using existing logic from poster.go
+	statusInfo, _ := analyzeFindingStatusInfo(comments, f.botUsername)
+	if len(statusInfo) == 0 {
 		return nil
 	}
 
-	// Extract triaged findings (acknowledged or disputed only)
-	findings := f.extractTriagedFindings(comments, statuses)
+	// Extract triaged findings with actual reply rationale
+	findings := f.extractTriagedFindings(comments, statusInfo)
 	if len(findings) == 0 {
 		return nil
 	}
@@ -75,9 +75,10 @@ func (f *TriageContextFetcher) FetchTriagedFindings(
 
 // extractTriagedFindings converts bot comments with acknowledged/disputed status
 // into TriagedFinding structs for prompt injection.
+// Uses the actual reply rationale when available for better LLM context.
 func (f *TriageContextFetcher) extractTriagedFindings(
 	comments []github.PullRequestComment,
-	statuses map[domain.FindingFingerprint]domain.FindingStatus,
+	statusInfo map[domain.FindingFingerprint]FindingStatusInfo,
 ) []domain.TriagedFinding {
 	var findings []domain.TriagedFinding
 
@@ -98,9 +99,9 @@ func (f *TriageContextFetcher) extractTriagedFindings(
 			continue // Not a structured finding comment
 		}
 
-		// Get status if available (may be empty for findings with no replies)
+		// Get status info if available (may be empty for findings with no replies)
 		// Include ALL bot findings regardless of status to prevent LLM from re-raising them
-		status := statuses[fp]
+		info := statusInfo[fp]
 
 		// Extract structured details
 		details := github.ExtractCommentDetails(comment.Body)
@@ -126,16 +127,24 @@ func (f *TriageContextFetcher) extractTriagedFindings(
 			Category:    details.Category,
 			Severity:    details.Severity,
 			Description: details.Description,
-			Status:      status,
+			Status:      info.Status,
 			Fingerprint: fp,
 		}
 
-		// Set status reason based on status
-		switch status {
+		// Set status reason - prefer actual rationale over generic text
+		switch info.Status {
 		case domain.StatusAcknowledged:
-			tf.StatusReason = domain.StatusReasonForAcknowledged()
+			if info.Rationale != "" {
+				tf.StatusReason = info.Rationale
+			} else {
+				tf.StatusReason = domain.StatusReasonForAcknowledged()
+			}
 		case domain.StatusDisputed:
-			tf.StatusReason = domain.StatusReasonForDisputed()
+			if info.Rationale != "" {
+				tf.StatusReason = info.Rationale
+			} else {
+				tf.StatusReason = domain.StatusReasonForDisputed()
+			}
 		default:
 			// StatusOpen or empty - finding was posted but not yet replied to
 			tf.Status = domain.StatusOpen

--- a/internal/usecase/github/triage_fetcher_test.go
+++ b/internal/usecase/github/triage_fetcher_test.go
@@ -115,6 +115,10 @@ func TestTriageContextFetcher_AcknowledgedFinding(t *testing.T) {
 	assert.Equal(t, domain.StatusAcknowledged, f.Status)
 	assert.Equal(t, "security", f.Category)
 	assert.Contains(t, f.Description, "Missing validation")
+
+	// Issue #189: StatusReason should contain the actual reply body, not generic text
+	assert.Contains(t, f.StatusReason, "tracking this in a separate issue",
+		"StatusReason should contain the actual reply rationale")
 }
 
 func TestTriageContextFetcher_DisputedFinding(t *testing.T) {
@@ -148,6 +152,10 @@ func TestTriageContextFetcher_DisputedFinding(t *testing.T) {
 	assert.Equal(t, "config.go", f.File)
 	assert.Equal(t, domain.StatusDisputed, f.Status)
 	assert.Equal(t, "performance", f.Category)
+
+	// Issue #189: StatusReason should contain the actual reply body, not generic text
+	assert.Contains(t, f.StatusReason, "O(1) amortized",
+		"StatusReason should contain the actual dispute rationale")
 }
 
 func TestTriageContextFetcher_MixedFindings(t *testing.T) {

--- a/internal/usecase/review/persona_prompt_builder.go
+++ b/internal/usecase/review/persona_prompt_builder.go
@@ -119,16 +119,18 @@ func (b *PersonaPromptBuilder) BuildWithSizeGuards(
 	}, truncResult, nil
 }
 
-// filterContext returns a copy of the context with prior findings filtered
-// to only include findings from the specified reviewer.
-func (b *PersonaPromptBuilder) filterContext(ctx ProjectContext, reviewer domain.Reviewer) ProjectContext {
-	filtered := ctx
-
-	if ctx.TriagedFindings != nil {
-		filtered.TriagedFindings = ctx.TriagedFindings.FilterByReviewer(reviewer.Name)
-	}
-
-	return filtered
+// filterContext returns a copy of the context for the specified reviewer.
+//
+// Note: Prior findings are NOT filtered by reviewer name. All personas see all
+// prior findings to prevent cross-persona duplicates. This is intentional:
+// if security-reviewer raised a finding that was disputed, architecture-reviewer
+// should also see it and not re-raise a similar concern.
+//
+// The reviewer name is preserved in each finding for attribution, but filtering
+// is disabled to prioritize deduplication over noise reduction.
+func (b *PersonaPromptBuilder) filterContext(ctx ProjectContext, _ domain.Reviewer) ProjectContext {
+	// Return context as-is without filtering prior findings
+	return ctx
 }
 
 // buildPersonaContent builds the persona-specific content string for a reviewer.

--- a/internal/usecase/review/persona_prompt_builder_test.go
+++ b/internal/usecase/review/persona_prompt_builder_test.go
@@ -203,7 +203,7 @@ func TestPersonaPromptBuilder_Build_PriorFindingsFiltering(t *testing.T) {
 		TargetRef: "feature/test",
 	}
 
-	t.Run("filters prior findings by reviewer name", func(t *testing.T) {
+	t.Run("includes all prior findings regardless of reviewer name", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := review.ProjectContext{
@@ -239,7 +239,8 @@ func TestPersonaPromptBuilder_Build_PriorFindingsFiltering(t *testing.T) {
 			},
 		}
 
-		// Security reviewer should only see security findings
+		// Security reviewer should see ALL findings (no filtering)
+		// This prevents cross-persona duplicates
 		result, err := builder.Build(ctx, baseDiff, baseReq, securityReviewer)
 		require.NoError(t, err)
 
@@ -247,11 +248,11 @@ func TestPersonaPromptBuilder_Build_PriorFindingsFiltering(t *testing.T) {
 		assert.Contains(t, result.Prompt, "SQL injection vulnerability")
 		assert.Contains(t, result.Prompt, "Credential exposure risk")
 
-		// Should NOT contain maintainability findings
-		assert.NotContains(t, result.Prompt, "Cyclomatic complexity too high")
+		// Should ALSO contain maintainability findings (no filtering)
+		assert.Contains(t, result.Prompt, "Cyclomatic complexity too high")
 	})
 
-	t.Run("excludes all prior findings for reviewer with no matching findings", func(t *testing.T) {
+	t.Run("all personas see all prior findings to prevent cross-persona duplicates", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := review.ProjectContext{
@@ -271,14 +272,15 @@ func TestPersonaPromptBuilder_Build_PriorFindingsFiltering(t *testing.T) {
 			},
 		}
 
-		// Maintainability reviewer should see no prior findings
+		// Maintainability reviewer should ALSO see security findings
+		// This prevents cross-persona duplicates
 		result, err := builder.Build(ctx, baseDiff, baseReq, maintainabilityReviewer)
 		require.NoError(t, err)
 
-		// Should NOT contain security findings
-		assert.NotContains(t, result.Prompt, "SQL injection")
-		// Should NOT have prior findings section at all
-		assert.NotContains(t, result.Prompt, "Previously Addressed Concerns")
+		// Should contain security findings even though it's a different reviewer
+		assert.Contains(t, result.Prompt, "SQL injection")
+		// Should have prior findings section
+		assert.Contains(t, result.Prompt, "Previously Addressed Concerns")
 	})
 
 	t.Run("handles nil triaged findings gracefully", func(t *testing.T) {

--- a/internal/usecase/review/prompt_builder.go
+++ b/internal/usecase/review/prompt_builder.go
@@ -433,6 +433,9 @@ func fileTypePriority(path string) int {
 // formatPriorFindings converts triaged findings into a human-readable section for the LLM prompt.
 // Returns an empty string if there are no triaged findings.
 //
+// The output includes fingerprints to help the LLM identify exact duplicates, and the actual
+// reply rationale (when available) to provide context for why findings were addressed.
+//
 // Note: This function does not currently impose size limits on the output. Large PRs with many
 // rounds of feedback may generate substantial prior context. Future enhancements may add
 // intelligent summarization or truncation if token limits become a concern in practice.
@@ -448,14 +451,14 @@ func formatPriorFindings(ctx *domain.TriagedFindingContext) string {
 	if len(acknowledged) > 0 {
 		sb.WriteString("### Acknowledged Findings (do NOT re-raise)\n\n")
 		sb.WriteString("The following concerns have been reviewed and accepted by the author. ")
-		sb.WriteString("Do not raise similar findings:\n\n")
+		sb.WriteString("Do not raise similar findings or variations of these concerns:\n\n")
 		for i, f := range acknowledged {
-			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d)\n",
-				i+1, f.Category, f.File, f.LineStart, f.LineEnd))
+			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d) [id: %s]\n",
+				i+1, f.Category, f.File, f.LineStart, f.LineEnd, f.Fingerprint))
 			// Indent continuation lines to maintain Markdown list structure
 			indentedDesc := strings.ReplaceAll(f.Description, "\n", "\n     ")
 			sb.WriteString(fmt.Sprintf("   - %s\n", indentedDesc))
-			sb.WriteString(fmt.Sprintf("   - Status: %s\n\n", f.StatusReason))
+			sb.WriteString(fmt.Sprintf("   - Rationale: %s\n\n", f.StatusReason))
 		}
 	}
 
@@ -464,14 +467,14 @@ func formatPriorFindings(ctx *domain.TriagedFindingContext) string {
 	if len(disputed) > 0 {
 		sb.WriteString("### Disputed Findings (do NOT re-raise)\n\n")
 		sb.WriteString("The following concerns were disputed as false positives or not applicable. ")
-		sb.WriteString("Do not raise similar findings:\n\n")
+		sb.WriteString("Do not raise similar findings or variations - the rationale below explains why:\n\n")
 		for i, f := range disputed {
-			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d)\n",
-				i+1, f.Category, f.File, f.LineStart, f.LineEnd))
+			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d) [id: %s]\n",
+				i+1, f.Category, f.File, f.LineStart, f.LineEnd, f.Fingerprint))
 			// Indent continuation lines to maintain Markdown list structure
 			indentedDesc := strings.ReplaceAll(f.Description, "\n", "\n     ")
 			sb.WriteString(fmt.Sprintf("   - %s\n", indentedDesc))
-			sb.WriteString(fmt.Sprintf("   - Status: %s\n\n", f.StatusReason))
+			sb.WriteString(fmt.Sprintf("   - Rationale: %s\n\n", f.StatusReason))
 		}
 	}
 
@@ -482,8 +485,8 @@ func formatPriorFindings(ctx *domain.TriagedFindingContext) string {
 		sb.WriteString("The following concerns were already raised in earlier review rounds. ")
 		sb.WriteString("Do not raise similar findings - they are already posted and awaiting response:\n\n")
 		for i, f := range open {
-			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d)\n",
-				i+1, f.Category, f.File, f.LineStart, f.LineEnd))
+			sb.WriteString(fmt.Sprintf("%d. **%s** in `%s` (lines %d-%d) [id: %s]\n",
+				i+1, f.Category, f.File, f.LineStart, f.LineEnd, f.Fingerprint))
 			// Indent continuation lines to maintain Markdown list structure
 			indentedDesc := strings.ReplaceAll(f.Description, "\n", "\n     ")
 			sb.WriteString(fmt.Sprintf("   - %s\n", indentedDesc))


### PR DESCRIPTION
## Summary

Improves INPUT-SIDE deduplication by giving the LLM better context about why findings were previously addressed. This addresses the root cause of repeated findings in multi-round PR reviews.

**Key changes:**
- Extract actual reply body as `StatusReason` instead of generic text
- Include fingerprint `[id: ...]` in formatted prior findings
- Remove per-reviewer filtering so all personas see all prior findings

## Before vs After

**Before** (generic):
```
1. **security** in `auth.go` (lines 10-15)
   - Missing input validation
   - Status: Author disputed as false positive
```

**After** (actual rationale):
```
1. **security** in `auth.go` (lines 10-15) [id: abc123...]
   - Missing input validation
   - Rationale: false positive - this is O(1) amortized because the map lookup dominates
```

## Test plan

- [x] `mage check` passes (format, vet, test)
- [x] `mage lint` passes
- [x] `mage buildAll` passes
- [x] Added test assertions for actual rationale extraction
- [x] Updated persona filtering tests for new behavior

Closes #189