### PR TITLE
feat: add blocking indicator to finding comments

### DIFF
--- a/internal/adapter/github/request_builder.go
+++ b/internal/adapter/github/request_builder.go
@@ -78,6 +78,11 @@ var defaultBlockingSeverities = map[string]bool{
 	"low":      false,
 }
 
+// isBlockingSeverity returns true if the severity level blocks PR approval by default.
+func isBlockingSeverity(severity string) bool {
+	return defaultBlockingSeverities[strings.ToLower(severity)]
+}
+
 // BuildReviewComments converts positioned findings to GitHub review comments.
 // Only findings with a valid DiffPosition (InDiff() == true) are included.
 // Each comment includes an embedded fingerprint for linking replies to findings.
@@ -105,13 +110,22 @@ func BuildReviewComments(findings []PositionedFinding) []ReviewComment {
 }
 
 // FormatFindingComment formats a domain.Finding as a GitHub-flavored Markdown comment.
+// The blocking indicator is determined by severity (critical/high = blocking by default).
 func FormatFindingComment(f domain.Finding) string {
 	var sb strings.Builder
 
-	// Header with severity and category
+	// Determine if finding is blocking based on severity
+	blocking := isBlockingSeverity(f.Severity)
+
+	// Header with severity, category, and blocking indicator
 	sb.WriteString(fmt.Sprintf("**Severity:** %s", f.Severity))
 	if f.Category != "" {
 		sb.WriteString(fmt.Sprintf(" | **Category:** %s", f.Category))
+	}
+	if blocking {
+		sb.WriteString(" | **Blocking:** yes")
+	} else {
+		sb.WriteString(" | **Blocking:** no")
 	}
 	sb.WriteString("\n\n")
 

--- a/internal/adapter/github/request_builder_test.go
+++ b/internal/adapter/github/request_builder_test.go
@@ -66,6 +66,7 @@ func TestFormatFindingComment(t *testing.T) {
 
 	assert.Contains(t, comment, "**Severity:** high")
 	assert.Contains(t, comment, "**Category:** security")
+	assert.Contains(t, comment, "**Blocking:** yes") // high severity = blocking
 	assert.Contains(t, comment, "SQL injection vulnerability")
 	assert.Contains(t, comment, "Use parameterized queries instead")
 }
@@ -77,6 +78,7 @@ func TestFormatFindingComment_NoSuggestion(t *testing.T) {
 	comment := github.FormatFindingComment(finding)
 
 	assert.Contains(t, comment, "Minor style issue")
+	assert.Contains(t, comment, "**Blocking:** no") // low severity = non-blocking
 	assert.NotContains(t, comment, "**Suggestion:**")
 }
 
@@ -107,6 +109,41 @@ func TestFormatFindingComment_SingleLine(t *testing.T) {
 
 	assert.Contains(t, comment, "Line 42")
 	assert.NotContains(t, comment, "Lines")
+}
+
+func TestFormatFindingComment_BlockingIndicator(t *testing.T) {
+	tests := []struct {
+		severity        string
+		expectedBlocked bool
+	}{
+		{"critical", true},
+		{"high", true},
+		{"medium", false},
+		{"low", false},
+		{"unknown", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.severity, func(t *testing.T) {
+			finding := domain.Finding{
+				File:        "test.go",
+				LineStart:   1,
+				Severity:    tt.severity,
+				Description: "Test finding",
+			}
+
+			comment := github.FormatFindingComment(finding)
+
+			if tt.expectedBlocked {
+				assert.Contains(t, comment, "**Blocking:** yes",
+					"severity %q should be blocking", tt.severity)
+			} else {
+				assert.Contains(t, comment, "**Blocking:** no",
+					"severity %q should not be blocking", tt.severity)
+			}
+		})
+	}
 }
 
 func TestDetermineReviewEvent_RequestChangesOnHighSeverity(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds "Blocking: yes/no" indicator to the finding comment header
- Blocking is determined by severity level: critical and high are blocking by default
- Makes review action expectations clearer at a glance

## Test plan
- [x] Added `TestFormatFindingComment_BlockingIndicator` covering all severity levels
- [x] Updated existing tests to verify blocking indicator presence
- [x] All tests pass (`mage check`)
- [x] Lint passes (`mage lint`)
- [x] Build succeeds (`mage buildAll`)

Resolves #183