### PR TITLE
feat(mcp): add sampling provider for zero-config code reviews

### DIFF
--- a/cmd/code-reviewer-mcp/main.go
+++ b/cmd/code-reviewer-mcp/main.go
@@ -103,17 +103,17 @@ func run() error {
 	// Build LLM providers from environment variables.
 	providers := buildProvidersFromEnv(&cfg)
 
-	// Create branch reviewer if providers are available.
+	// Create merger and reviewer registry for branch reviews.
+	// These are needed for both direct providers and sampling fallback.
+	merger := merge.NewIntelligentMerger(nil)
+	reviewerRegistry, err := review.NewReviewerRegistry(&cfg)
+	if err != nil {
+		log.Printf("warning: reviewer registry creation failed, using defaults: %v", err)
+	}
+
+	// Create branch reviewer if providers are available (direct API access).
 	var branchReviewer mcpadapter.BranchReviewer
 	if len(providers) > 0 {
-		// Create minimal orchestrator for branch reviews.
-		// Note: Merger takes nil store - precision priors will use defaults (same as CLI).
-		merger := merge.NewIntelligentMerger(nil)
-		reviewerRegistry, err := review.NewReviewerRegistry(&cfg)
-		if err != nil {
-			log.Printf("warning: reviewer registry creation failed, using defaults: %v", err)
-		}
-
 		orchestrator := review.NewOrchestrator(review.OrchestratorDeps{
 			Git:              gitEngine,
 			Providers:        providers,
@@ -124,10 +124,17 @@ func run() error {
 	}
 
 	// Create and configure the MCP server.
+	// Even if branchReviewer is nil, the server can fall back to sampling
+	// if the Git/Merger/ReviewerRegistry deps are provided.
 	server := mcpadapter.NewServer(mcpadapter.ServerDeps{
 		PRService:      prService,
 		TriageService:  triageService,
 		BranchReviewer: branchReviewer,
+		// Sampling fallback dependencies
+		Git:              gitEngine,
+		Merger:           merger,
+		ReviewerRegistry: reviewerRegistry,
+		Config:           &cfg,
 	})
 
 	// Run the server (blocks until context is cancelled or error occurs).

--- a/internal/adapter/llm/sampling/doc.go
+++ b/internal/adapter/llm/sampling/doc.go
@@ -1,0 +1,62 @@
+// Package sampling provides an MCP sampling-based code review provider.
+//
+// This package implements the review.Provider interface using MCP's sampling
+// capability (CreateMessage) instead of direct LLM API calls. This allows
+// the code reviewer MCP tools to work without requiring users to have their
+// own LLM API keys.
+//
+// # Architecture
+//
+// When a user runs review_branch or review_pr through Claude Code (or another
+// MCP client that supports sampling), this provider routes the review request
+// back to the client's LLM. The flow is:
+//
+//  1. User: "review my branch against main"
+//  2. Claude Code → MCP Server: review_branch(base_ref: "main")
+//  3. MCP Server creates sampling Provider with session
+//  4. Provider → Claude Code: CreateMessage(prompt: review_prompt)
+//  5. Claude Code performs completion using its own LLM access
+//  6. Claude Code → Provider: CreateMessageResult(content: JSON review)
+//  7. Provider parses JSON, returns domain.Review
+//  8. MCP Server → Claude Code: review findings
+//
+// # Usage
+//
+// The sampling provider is used as a fallback when no direct API keys are
+// available. It's created per-request since MCP sessions are request-scoped:
+//
+//	// In MCP tool handler:
+//	func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolRequest, input Input) (...) {
+//	    // Create sampling provider with this request's session
+//	    sessionProvider := func() sampling.Session { return req.Session }
+//	    fallbackProvider := sampling.NewProvider(sessionProvider)
+//
+//	    // Use as fallback if no direct providers available
+//	    providers := getEffectiveProviders(s.directProviders, fallbackProvider)
+//	    // ...
+//	}
+//
+// # Limitations
+//
+// Compared to direct API providers, the sampling provider has some limitations:
+//
+//   - No token usage or cost tracking (MCP sampling doesn't expose this)
+//   - Model selection is up to the client (hints are advisory only)
+//   - Additional round-trip latency through the MCP protocol
+//   - Client may modify or truncate system prompts
+//
+// For these reasons, sampling is the fallback, not the default. When users
+// have direct API keys configured, those are preferred.
+//
+// # Testing
+//
+// The Session interface abstracts the MCP session for testing:
+//
+//	type mockSession struct {
+//	    createMessageFunc func(...) (*mcp.CreateMessageResult, error)
+//	}
+//
+//	func (m *mockSession) CreateMessage(...) (*mcp.CreateMessageResult, error) {
+//	    return m.createMessageFunc(...)
+//	}
+package sampling

--- a/internal/adapter/llm/sampling/provider.go
+++ b/internal/adapter/llm/sampling/provider.go
@@ -1,0 +1,103 @@
+// Package sampling provides an LLM provider that uses MCP sampling.
+// Instead of making direct API calls, it requests the connected MCP client
+// (e.g., Claude Code) to perform completions on its behalf.
+//
+// This enables zero-configuration usage when the user doesn't have direct
+// API keys but is using the tool through an MCP-compatible assistant.
+package sampling
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm"
+	llmhttp "github.com/bkyoung/code-reviewer/internal/adapter/llm/http"
+	"github.com/bkyoung/code-reviewer/internal/domain"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const providerName = "sampling"
+
+// Session defines the subset of mcp.ServerSession needed for sampling.
+// This interface allows testing without a real MCP connection.
+type Session interface {
+	CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error)
+}
+
+// SessionProvider is a function that returns the current MCP session.
+// This allows the provider to be created once but get the session per-request,
+// since sessions are request-scoped in MCP tool handlers.
+type SessionProvider func() Session
+
+// Provider implements review.Provider using MCP sampling.
+// Instead of making direct LLM API calls, it requests the MCP client
+// to perform completions on its behalf via CreateMessage.
+type Provider struct {
+	getSession SessionProvider
+}
+
+// NewProvider creates a sampling-based review provider.
+// The sessionProvider function is called for each Review request to get
+// the current session, allowing session-per-request semantics.
+func NewProvider(sessionProvider SessionProvider) *Provider {
+	return &Provider{
+		getSession: sessionProvider,
+	}
+}
+
+// Review performs a code review by requesting the MCP client to sample.
+// It sends the prompt to the connected client via CreateMessage and parses
+// the JSON response using the same parser as other providers.
+func (p *Provider) Review(ctx context.Context, req review.ProviderRequest) (domain.Review, error) {
+	session := p.getSession()
+	if session == nil {
+		return domain.Review{}, fmt.Errorf("no MCP session available for sampling")
+	}
+
+	// Build the sampling request
+	// The prompt is passed as a user message; max tokens controls output size
+	samplingReq := &mcp.CreateMessageParams{
+		Messages: []*mcp.SamplingMessage{
+			{
+				Role:    "user", // MCP Role is a string type
+				Content: &mcp.TextContent{Text: req.Prompt},
+			},
+		},
+		MaxTokens: int64(req.MaxSize),
+	}
+
+	// Request completion from MCP client
+	result, err := session.CreateMessage(ctx, samplingReq)
+	if err != nil {
+		return domain.Review{}, fmt.Errorf("sampling request failed: %w", err)
+	}
+
+	// Extract text content from result
+	textContent, ok := result.Content.(*mcp.TextContent)
+	if !ok {
+		return domain.Review{}, fmt.Errorf("unexpected content type: %T (expected TextContent)", result.Content)
+	}
+
+	// Parse the review response using shared JSON parser
+	// This handles markdown-wrapped JSON and flexible field names (camelCase/snake_case)
+	summary, findings, err := llmhttp.ParseReviewResponse(textContent.Text)
+	if err != nil {
+		return domain.Review{}, fmt.Errorf("parse sampling response: %w", err)
+	}
+
+	return domain.Review{
+		ProviderName: providerName,
+		ModelName:    result.Model,
+		Summary:      summary,
+		Findings:     findings,
+		// Note: MCP sampling doesn't provide token counts or cost information
+		// These remain zero, which is acceptable for the fallback use case
+	}, nil
+}
+
+// EstimateTokens returns an estimated token count using tiktoken.
+// Uses the shared estimation logic that approximates Claude's tokenizer.
+func (p *Provider) EstimateTokens(text string) int {
+	return llm.EstimateTokens(text)
+}

--- a/internal/adapter/llm/sampling/provider_test.go
+++ b/internal/adapter/llm/sampling/provider_test.go
@@ -1,0 +1,279 @@
+package sampling
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSession implements the subset of ServerSession we need for testing.
+type mockSession struct {
+	createMessageFunc func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error)
+}
+
+func (m *mockSession) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+	if m.createMessageFunc != nil {
+		return m.createMessageFunc(ctx, params)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func TestProvider_Review_Success(t *testing.T) {
+	// Arrange: mock session returns valid JSON review
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return &mcp.CreateMessageResult{
+				Content: &mcp.TextContent{Text: `{
+					"summary": "Found 1 issue",
+					"findings": [
+						{
+							"file": "main.go",
+							"lineStart": 10,
+							"lineEnd": 12,
+							"severity": "high",
+							"category": "bug",
+							"description": "Nil pointer dereference"
+						}
+					]
+				}`},
+				Model:      "claude-sonnet-4-20250514",
+				Role:       "assistant",
+				StopReason: "end_turn",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	// Act
+	result, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt:       "Review this code...",
+		Seed:         12345,
+		MaxSize:      8192,
+		ReviewerName: "test-reviewer",
+	})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, providerName, result.ProviderName)
+	assert.Equal(t, "claude-sonnet-4-20250514", result.ModelName)
+	assert.Equal(t, "Found 1 issue", result.Summary)
+	require.Len(t, result.Findings, 1)
+	assert.Equal(t, "main.go", result.Findings[0].File)
+	assert.Equal(t, 10, result.Findings[0].LineStart)
+	assert.Equal(t, "high", result.Findings[0].Severity)
+	assert.Equal(t, "bug", result.Findings[0].Category)
+	assert.Equal(t, "Nil pointer dereference", result.Findings[0].Description)
+}
+
+func TestProvider_Review_MarkdownWrappedJSON(t *testing.T) {
+	// Test that we can handle JSON wrapped in markdown code blocks
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return &mcp.CreateMessageResult{
+				Content: &mcp.TextContent{Text: "```json\n{\"summary\": \"No issues\", \"findings\": []}\n```"},
+				Model:   "claude-sonnet-4-20250514",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	result, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "No issues", result.Summary)
+	assert.Empty(t, result.Findings)
+}
+
+func TestProvider_Review_NoSession(t *testing.T) {
+	// Test error when session provider returns nil
+	provider := NewProvider(func() Session { return nil })
+
+	_, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no MCP session available")
+}
+
+func TestProvider_Review_SessionError(t *testing.T) {
+	// Test error propagation from CreateMessage
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return nil, errors.New("sampling failed: client disconnected")
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	_, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sampling request failed")
+	assert.Contains(t, err.Error(), "client disconnected")
+}
+
+func TestProvider_Review_InvalidJSON(t *testing.T) {
+	// Test handling of invalid JSON response
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return &mcp.CreateMessageResult{
+				Content: &mcp.TextContent{Text: "This is not valid JSON at all"},
+				Model:   "test-model",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	_, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+}
+
+func TestProvider_Review_UnexpectedContentType(t *testing.T) {
+	// Test handling of non-text content
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return &mcp.CreateMessageResult{
+				Content: &mcp.ImageContent{Data: []byte("base64data"), MIMEType: "image/png"},
+				Model:   "test-model",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	_, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected content type")
+}
+
+func TestProvider_Review_PromptPassthrough(t *testing.T) {
+	// Verify the prompt is correctly passed to CreateMessage
+	var capturedParams *mcp.CreateMessageParams
+
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			capturedParams = params
+			return &mcp.CreateMessageResult{
+				Content: &mcp.TextContent{Text: `{"summary": "ok", "findings": []}`},
+				Model:   "test-model",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	_, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt:  "Please review this code:\n\n```go\npackage main\n```",
+		MaxSize: 4096,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedParams)
+
+	// Verify messages were constructed correctly
+	require.Len(t, capturedParams.Messages, 1)
+	msg := capturedParams.Messages[0]
+	assert.Equal(t, mcp.Role("user"), msg.Role)
+
+	textContent, ok := msg.Content.(*mcp.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", msg.Content)
+	assert.Contains(t, textContent.Text, "Please review this code")
+
+	// Verify max tokens
+	assert.Equal(t, int64(4096), capturedParams.MaxTokens)
+}
+
+func TestProvider_EstimateTokens(t *testing.T) {
+	provider := NewProvider(func() Session { return nil })
+
+	// Test token estimation (should use tiktoken-based estimation)
+	tokens := provider.EstimateTokens("Hello, world!")
+	assert.Greater(t, tokens, 0)
+
+	// Longer text should have more tokens
+	longText := "This is a longer piece of text that should have more tokens than the short one."
+	longTokens := provider.EstimateTokens(longText)
+	assert.Greater(t, longTokens, tokens)
+}
+
+func TestProvider_SnakeCaseJSON(t *testing.T) {
+	// Test that snake_case JSON fields are handled (LLMs sometimes ignore schema)
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return &mcp.CreateMessageResult{
+				Content: &mcp.TextContent{Text: `{
+					"summary": "Found 1 issue",
+					"findings": [
+						{
+							"file": "main.go",
+							"line_start": 10,
+							"line_end": 12,
+							"severity": "medium",
+							"category": "style",
+							"description": "Variable naming"
+						}
+					]
+				}`},
+				Model: "test-model",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	result, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1)
+	// The shared parser handles snake_case line_start/line_end
+	assert.Equal(t, 10, result.Findings[0].LineStart)
+	assert.Equal(t, 12, result.Findings[0].LineEnd)
+}
+
+// TestProvider_ImplementsInterface verifies the provider implements review.Provider
+func TestProvider_ImplementsInterface(t *testing.T) {
+	var _ review.Provider = (*Provider)(nil)
+}
+
+func TestProvider_EmptyFindings(t *testing.T) {
+	session := &mockSession{
+		createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+			return &mcp.CreateMessageResult{
+				Content: &mcp.TextContent{Text: `{"summary": "Code looks great!", "findings": []}`},
+				Model:   "claude-sonnet-4-20250514",
+			}, nil
+		},
+	}
+
+	provider := NewProvider(func() Session { return session })
+
+	result, err := provider.Review(context.Background(), review.ProviderRequest{
+		Prompt: "Review this...",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Code looks great!", result.Summary)
+	assert.Empty(t, result.Findings)
+}

--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/sampling"
 	"github.com/bkyoung/code-reviewer/internal/domain"
 	"github.com/bkyoung/code-reviewer/internal/usecase/review"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -567,13 +568,7 @@ Use this for:
 }
 
 func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolRequest, input ReviewBranchInput) (*mcp.CallToolResult, ReviewBranchOutput, error) {
-	// Check dependency availability
-	if s.deps.BranchReviewer == nil {
-		return notImplementedResult("review_branch requires LLM providers - set ANTHROPIC_API_KEY or OPENAI_API_KEY"),
-			ReviewBranchOutput{}, nil
-	}
-
-	// Validate input
+	// Validate input first (before checking dependencies)
 	if input.BaseRef == "" {
 		return &mcp.CallToolResult{
 			IsError: true,
@@ -581,6 +576,28 @@ func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: "base_ref is required"},
 			},
 		}, ReviewBranchOutput{}, nil
+	}
+
+	// Determine which reviewer to use:
+	// 1. Prefer direct BranchReviewer if available (from API keys)
+	// 2. Fall back to sampling if client supports it
+	reviewer := s.deps.BranchReviewer
+	if reviewer == nil {
+		// Try to create a sampling-based reviewer
+		var session *mcp.ServerSession
+		if req != nil {
+			session = req.Session
+		}
+		samplingReviewer, err := s.createSamplingReviewer(session)
+		if err != nil {
+			// Provide helpful error message based on what's missing
+			return notImplementedResult(
+					"review_branch requires either: " +
+						"(1) LLM API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY), or " +
+						"(2) an MCP client that supports sampling"),
+				ReviewBranchOutput{}, nil
+		}
+		reviewer = samplingReviewer
 	}
 
 	// Build BranchRequest
@@ -593,7 +610,7 @@ func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolReques
 	}
 
 	// Execute review
-	result, err := s.deps.BranchReviewer.ReviewBranch(ctx, branchReq)
+	result, err := reviewer.ReviewBranch(ctx, branchReq)
 	if err != nil {
 		return nil, ReviewBranchOutput{}, fmt.Errorf("review branch: %w", err)
 	}
@@ -637,4 +654,73 @@ func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolReques
 			&mcp.TextContent{Text: output.Message},
 		},
 	}, output, nil
+}
+
+// =============================================================================
+// Sampling Fallback Support
+// =============================================================================
+
+// createSamplingReviewer creates a branch reviewer that uses MCP sampling.
+// It returns an error if:
+// - The session is nil
+// - The client doesn't support sampling
+// - Required dependencies (Git, Merger) are not configured
+func (s *Server) createSamplingReviewer(session *mcp.ServerSession) (BranchReviewer, error) {
+	// Check for required dependencies
+	if s.deps.Git == nil {
+		return nil, fmt.Errorf("git engine not configured")
+	}
+	if s.deps.Merger == nil {
+		return nil, fmt.Errorf("merger not configured")
+	}
+
+	// Check session availability
+	if session == nil {
+		return nil, fmt.Errorf("no session available")
+	}
+
+	// Check if client supports sampling
+	if !clientSupportsSampling(session) {
+		return nil, fmt.Errorf("client does not support sampling")
+	}
+
+	// Create sampling provider with session
+	// Note: We capture the session in a closure so the provider can use it
+	sessionProvider := func() sampling.Session {
+		return &serverSessionAdapter{session}
+	}
+	samplingProvider := sampling.NewProvider(sessionProvider)
+
+	// Create orchestrator with sampling provider
+	orchestrator := review.NewOrchestrator(review.OrchestratorDeps{
+		Git:              s.deps.Git,
+		Providers:        map[string]review.Provider{"sampling": samplingProvider},
+		Merger:           s.deps.Merger,
+		ReviewerRegistry: s.deps.ReviewerRegistry,
+	})
+
+	return orchestrator, nil
+}
+
+// clientSupportsSampling checks if the connected MCP client supports sampling.
+// Sampling is indicated by the presence of the sampling capability in client info.
+func clientSupportsSampling(session *mcp.ServerSession) bool {
+	if session == nil {
+		return false
+	}
+	params := session.InitializeParams()
+	if params == nil || params.Capabilities == nil {
+		return false
+	}
+	return params.Capabilities.Sampling != nil
+}
+
+// serverSessionAdapter adapts mcp.ServerSession to sampling.Session interface.
+// This allows the sampling provider to use the MCP session without importing the mcp package.
+type serverSessionAdapter struct {
+	session *mcp.ServerSession
+}
+
+func (a *serverSessionAdapter) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+	return a.session.CreateMessage(ctx, params)
 }

--- a/internal/adapter/mcp/review_handlers_test.go
+++ b/internal/adapter/mcp/review_handlers_test.go
@@ -964,7 +964,7 @@ func (m *mockBranchReviewer) ReviewBranch(ctx context.Context, req review.Branch
 }
 
 func TestHandleReviewBranch(t *testing.T) {
-	t.Run("returns not implemented when BranchReviewer is nil", func(t *testing.T) {
+	t.Run("returns not implemented when BranchReviewer is nil and no sampling", func(t *testing.T) {
 		s := &Server{deps: ServerDeps{}}
 
 		input := ReviewBranchInput{
@@ -976,10 +976,11 @@ func TestHandleReviewBranch(t *testing.T) {
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
 		assert.Empty(t, output.Findings)
-		// Should provide helpful message about API keys
+		// Should provide helpful message about API keys or sampling
 		textContent, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
-		assert.Contains(t, textContent.Text, "LLM providers")
+		assert.Contains(t, textContent.Text, "LLM API keys")
+		assert.Contains(t, textContent.Text, "sampling")
 	})
 
 	t.Run("validates required base_ref", func(t *testing.T) {

--- a/internal/adapter/mcp/server.go
+++ b/internal/adapter/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 
+	"github.com/bkyoung/code-reviewer/internal/config"
 	"github.com/bkyoung/code-reviewer/internal/domain"
 	"github.com/bkyoung/code-reviewer/internal/usecase/review"
 	"github.com/bkyoung/code-reviewer/internal/usecase/triage"
@@ -31,6 +32,18 @@ type PRMetadataFetcher interface {
 // This is implemented by review.Orchestrator.
 type BranchReviewer interface {
 	ReviewBranch(ctx context.Context, req review.BranchRequest) (review.Result, error)
+}
+
+// GitEngine provides git operations for branch reviews.
+// This is implemented by git.Engine.
+type GitEngine interface {
+	review.GitEngine
+}
+
+// Merger merges findings from multiple providers.
+// This is implemented by merge.IntelligentMerger.
+type Merger interface {
+	review.Merger
 }
 
 const (
@@ -62,8 +75,24 @@ type ServerDeps struct {
 	RemoteGitHubClient PRMetadataFetcher
 
 	// BranchReviewer reviews local git branches.
-	// Optional: only required for review_branch tool.
+	// Optional: only required for review_branch tool when direct API keys are available.
 	BranchReviewer BranchReviewer
+
+	// === Sampling Fallback Dependencies ===
+	// These are used to create a per-request orchestrator when BranchReviewer is nil
+	// but the client supports MCP sampling.
+
+	// Git provides git operations for branch reviews via sampling fallback.
+	Git GitEngine
+
+	// Merger merges findings from multiple providers.
+	Merger Merger
+
+	// ReviewerRegistry provides reviewer configurations for persona support.
+	ReviewerRegistry review.ReviewerRegistry
+
+	// Config provides configuration for reviewers and other settings.
+	Config *config.Config
 }
 
 // Server wraps the MCP server and provides triage tools.


### PR DESCRIPTION
## Summary

- Implement MCP sampling-based code review provider that enables `review_branch` to work without direct LLM API keys
- When no API keys are configured, the MCP server falls back to requesting completions from the connected client (e.g., Claude Code) via MCP's `CreateMessage`
- Add capability detection for client sampling support

## Changes

- Add `internal/adapter/llm/sampling` package with `Provider` implementation
- Wire sampling fallback into `review_branch` handler
- Update server deps to support per-request orchestrator creation

## Test plan

- [x] Unit tests for sampling provider (11 tests covering success, errors, edge cases)
- [x] Updated handler tests for sampling fallback error messages
- [x] `mage check` passes
- [x] `mage testRace` passes

Closes #196