### PR TITLE
feat(mcp): add provider factory for reusable sampling fallback

### DIFF
--- a/cmd/code-reviewer-mcp/main.go
+++ b/cmd/code-reviewer-mcp/main.go
@@ -10,8 +10,7 @@ import (
 
 	"github.com/bkyoung/code-reviewer/internal/adapter/git"
 	"github.com/bkyoung/code-reviewer/internal/adapter/github"
-	"github.com/bkyoung/code-reviewer/internal/adapter/llm/anthropic"
-	"github.com/bkyoung/code-reviewer/internal/adapter/llm/openai"
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/provider"
 	mcpadapter "github.com/bkyoung/code-reviewer/internal/adapter/mcp"
 	"github.com/bkyoung/code-reviewer/internal/config"
 	"github.com/bkyoung/code-reviewer/internal/usecase/merge"
@@ -89,52 +88,55 @@ func run() error {
 	})
 
 	// Load config for reviewer and provider settings.
-	// Config is optional - failure just means review_branch won't be available.
 	cfg, err := config.Load(config.LoaderOptions{
 		ConfigPaths: defaultConfigPaths(),
 		FileName:    "cr",
 		EnvPrefix:   "CR",
 	})
 	if err != nil {
-		log.Printf("warning: config load failed, review_branch will be unavailable: %v", err)
+		log.Printf("warning: config load failed: %v", err)
 		cfg = config.Config{}
 	}
 
-	// Build LLM providers from environment variables.
-	providers := buildProvidersFromEnv(&cfg)
+	// Create provider factory - builds direct providers from environment variables
+	// and supports sampling fallback for zero-config usage.
+	providerFactory := provider.NewFactory(provider.FactoryOptions{
+		Config: &cfg,
+	})
 
-	// Create merger and reviewer registry for branch reviews.
-	// These are needed for both direct providers and sampling fallback.
+	// Create merger and reviewer registry for reviews.
 	merger := merge.NewIntelligentMerger(nil)
 	reviewerRegistry, err := review.NewReviewerRegistry(&cfg)
 	if err != nil {
 		log.Printf("warning: reviewer registry creation failed, using defaults: %v", err)
 	}
 
-	// Create branch reviewer if providers are available (direct API access).
+	// Create branch/PR reviewer if direct providers are available.
+	// If not available, the server will fall back to per-request creation using
+	// the factory (which may use sampling if the client supports it).
 	var branchReviewer mcpadapter.BranchReviewer
-	if len(providers) > 0 {
+	var prReviewer mcpadapter.PRReviewer
+	if providerFactory.HasDirectProviders() {
 		orchestrator := review.NewOrchestrator(review.OrchestratorDeps{
 			Git:              gitEngine,
-			Providers:        providers,
+			Providers:        providerFactory.DirectProviders(),
 			Merger:           merger,
 			ReviewerRegistry: reviewerRegistry,
 		})
 		branchReviewer = orchestrator
+		prReviewer = orchestrator
 	}
 
 	// Create and configure the MCP server.
-	// Even if branchReviewer is nil, the server can fall back to sampling
-	// if the Git/Merger/ReviewerRegistry deps are provided.
 	server := mcpadapter.NewServer(mcpadapter.ServerDeps{
-		PRService:      prService,
-		TriageService:  triageService,
-		BranchReviewer: branchReviewer,
-		// Sampling fallback dependencies
+		PRService:        prService,
+		TriageService:    triageService,
+		BranchReviewer:   branchReviewer,
+		PRReviewer:       prReviewer,
+		ProviderFactory:  providerFactory,
 		Git:              gitEngine,
 		Merger:           merger,
 		ReviewerRegistry: reviewerRegistry,
-		Config:           &cfg,
 	})
 
 	// Run the server (blocks until context is cancelled or error occurs).
@@ -145,44 +147,4 @@ func run() error {
 func defaultConfigPaths() []string {
 	home, _ := os.UserHomeDir()
 	return []string{".", home + "/.config/cr"}
-}
-
-// buildProvidersFromEnv creates LLM providers from environment variables.
-// Returns an empty map if no API keys are configured.
-func buildProvidersFromEnv(cfg *config.Config) map[string]review.Provider {
-	providers := make(map[string]review.Provider)
-
-	// Anthropic provider
-	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
-		model := "claude-sonnet-4-20250514" // default
-		providerCfg := config.ProviderConfig{}
-		if cfg != nil {
-			if pc, ok := cfg.Providers["anthropic"]; ok {
-				providerCfg = pc
-				if pc.Model != "" {
-					model = pc.Model
-				}
-			}
-		}
-		client := anthropic.NewHTTPClient(key, model, providerCfg, cfg.HTTP)
-		providers["anthropic"] = anthropic.NewProvider(model, client)
-	}
-
-	// OpenAI provider
-	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
-		model := "gpt-4o" // default
-		providerCfg := config.ProviderConfig{}
-		if cfg != nil {
-			if pc, ok := cfg.Providers["openai"]; ok {
-				providerCfg = pc
-				if pc.Model != "" {
-					model = pc.Model
-				}
-			}
-		}
-		client := openai.NewHTTPClient(key, model, providerCfg, cfg.HTTP)
-		providers["openai"] = openai.NewProvider(model, client)
-	}
-
-	return providers
 }

--- a/internal/adapter/llm/provider/factory.go
+++ b/internal/adapter/llm/provider/factory.go
@@ -1,0 +1,173 @@
+// Package provider provides a factory for creating LLM providers.
+// It handles building providers from environment variables and configuration,
+// and provides a centralized fallback mechanism for MCP sampling.
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/anthropic"
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/openai"
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/sampling"
+	"github.com/bkyoung/code-reviewer/internal/config"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SamplingSession defines the subset of mcp.ServerSession needed for sampling.
+// This interface allows the factory to work with MCP sessions without
+// depending on the full mcp.ServerSession type.
+type SamplingSession interface {
+	CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error)
+	InitializeParams() *mcp.InitializeParams
+}
+
+// FactoryOptions configures the provider factory.
+type FactoryOptions struct {
+	// Config provides provider-specific settings (models, timeouts, etc.)
+	Config *config.Config
+}
+
+// Factory creates and manages LLM providers.
+// It handles building providers from environment variables and configuration,
+// and provides a centralized fallback mechanism for MCP sampling.
+type Factory struct {
+	config          *config.Config
+	directProviders map[string]review.Provider
+}
+
+// NewFactory creates a new provider factory.
+// Direct providers are built immediately from environment variables.
+func NewFactory(opts FactoryOptions) *Factory {
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	f := &Factory{
+		config:          cfg,
+		directProviders: make(map[string]review.Provider),
+	}
+
+	f.buildDirectProviders()
+
+	return f
+}
+
+// buildDirectProviders creates providers from environment variables.
+func (f *Factory) buildDirectProviders() {
+	// Anthropic provider
+	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		model := "claude-sonnet-4-20250514" // default
+		providerCfg := config.ProviderConfig{}
+		if f.config != nil {
+			if pc, ok := f.config.Providers["anthropic"]; ok {
+				providerCfg = pc
+				if pc.Model != "" {
+					model = pc.Model
+				}
+			}
+		}
+		client := anthropic.NewHTTPClient(key, model, providerCfg, f.config.HTTP)
+		f.directProviders["anthropic"] = anthropic.NewProvider(model, client)
+	}
+
+	// OpenAI provider
+	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+		model := "gpt-4o" // default
+		providerCfg := config.ProviderConfig{}
+		if f.config != nil {
+			if pc, ok := f.config.Providers["openai"]; ok {
+				providerCfg = pc
+				if pc.Model != "" {
+					model = pc.Model
+				}
+			}
+		}
+		client := openai.NewHTTPClient(key, model, providerCfg, f.config.HTTP)
+		f.directProviders["openai"] = openai.NewProvider(model, client)
+	}
+}
+
+// DirectProviders returns the providers built from API keys.
+// Returns an empty map if no API keys were configured.
+func (f *Factory) DirectProviders() map[string]review.Provider {
+	return f.directProviders
+}
+
+// HasDirectProviders returns true if any direct providers are available.
+func (f *Factory) HasDirectProviders() bool {
+	return len(f.directProviders) > 0
+}
+
+// CreateSamplingProvider creates a provider that uses MCP sampling.
+// The session must support sampling (check with ClientSupportsSampling first).
+// Returns an error if the session is nil or doesn't support sampling.
+func (f *Factory) CreateSamplingProvider(session SamplingSession) (review.Provider, error) {
+	if session == nil {
+		return nil, fmt.Errorf("cannot create sampling provider: session is nil")
+	}
+
+	if !ClientSupportsSampling(session) {
+		return nil, fmt.Errorf("cannot create sampling provider: client does not support sampling")
+	}
+
+	// Create a session provider that returns the session.
+	// The session is captured in this closure.
+	sessionProvider := func() sampling.Session {
+		return &samplingSessionAdapter{session}
+	}
+
+	return sampling.NewProvider(sessionProvider), nil
+}
+
+// EffectiveProviders returns the providers to use for a review request.
+// Priority:
+//  1. Direct providers (from API keys) - if available, these are always used
+//  2. Sampling provider (from MCP session) - used as fallback when no API keys
+//
+// Returns an error if no providers are available (no API keys and no sampling support).
+func (f *Factory) EffectiveProviders(session SamplingSession) (map[string]review.Provider, error) {
+	// Prefer direct providers
+	if f.HasDirectProviders() {
+		return f.directProviders, nil
+	}
+
+	// Fall back to sampling
+	samplingProvider, err := f.CreateSamplingProvider(session)
+	if err != nil {
+		return nil, fmt.Errorf("no providers available: no API keys configured and %w", err)
+	}
+
+	return map[string]review.Provider{"sampling": samplingProvider}, nil
+}
+
+// ClientSupportsSampling checks if the connected MCP client supports sampling.
+// Sampling is indicated by the presence of the Sampling capability in client info.
+func ClientSupportsSampling(session SamplingSession) bool {
+	if session == nil {
+		return false
+	}
+
+	params := session.InitializeParams()
+	if params == nil {
+		return false
+	}
+
+	if params.Capabilities == nil {
+		return false
+	}
+
+	return params.Capabilities.Sampling != nil
+}
+
+// samplingSessionAdapter adapts SamplingSession to sampling.Session interface.
+type samplingSessionAdapter struct {
+	session SamplingSession
+}
+
+func (a *samplingSessionAdapter) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+	return a.session.CreateMessage(ctx, params)
+}

--- a/internal/adapter/llm/provider/factory_test.go
+++ b/internal/adapter/llm/provider/factory_test.go
@@ -1,0 +1,319 @@
+package provider_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/provider"
+	"github.com/bkyoung/code-reviewer/internal/config"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSession implements provider.SamplingSession for testing.
+type mockSession struct {
+	createMessageFunc func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error)
+	initializeParams  *mcp.InitializeParams
+	supportsSampling  bool
+}
+
+func (m *mockSession) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+	if m.createMessageFunc != nil {
+		return m.createMessageFunc(ctx, params)
+	}
+	return &mcp.CreateMessageResult{
+		Content: &mcp.TextContent{Text: `{"summary": "test", "findings": []}`},
+		Model:   "test-model",
+	}, nil
+}
+
+func (m *mockSession) InitializeParams() *mcp.InitializeParams {
+	if m.initializeParams != nil {
+		return m.initializeParams
+	}
+	if m.supportsSampling {
+		return &mcp.InitializeParams{
+			Capabilities: &mcp.ClientCapabilities{
+				Sampling: &mcp.SamplingCapabilities{},
+			},
+		}
+	}
+	return &mcp.InitializeParams{
+		Capabilities: &mcp.ClientCapabilities{},
+	}
+}
+
+// =============================================================================
+// Factory Creation Tests
+// =============================================================================
+
+func TestNewFactory_NoProviders(t *testing.T) {
+	// Clear any existing API keys
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	assert.NotNil(t, factory)
+	assert.Empty(t, factory.DirectProviders())
+}
+
+func TestNewFactory_WithAnthropicKey(t *testing.T) {
+	// Set up test environment
+	originalKey := os.Getenv("ANTHROPIC_API_KEY")
+	defer os.Setenv("ANTHROPIC_API_KEY", originalKey)
+	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Len(t, providers, 1)
+	assert.Contains(t, providers, "anthropic")
+}
+
+func TestNewFactory_WithOpenAIKey(t *testing.T) {
+	// Set up test environment
+	originalKey := os.Getenv("OPENAI_API_KEY")
+	defer os.Setenv("OPENAI_API_KEY", originalKey)
+	os.Setenv("OPENAI_API_KEY", "test-openai-key")
+	os.Unsetenv("ANTHROPIC_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Len(t, providers, 1)
+	assert.Contains(t, providers, "openai")
+}
+
+func TestNewFactory_WithBothKeys(t *testing.T) {
+	// Set up test environment
+	originalAnthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+	originalOpenAIKey := os.Getenv("OPENAI_API_KEY")
+	defer func() {
+		os.Setenv("ANTHROPIC_API_KEY", originalAnthropicKey)
+		os.Setenv("OPENAI_API_KEY", originalOpenAIKey)
+	}()
+	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	os.Setenv("OPENAI_API_KEY", "test-openai-key")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Len(t, providers, 2)
+	assert.Contains(t, providers, "anthropic")
+	assert.Contains(t, providers, "openai")
+}
+
+// =============================================================================
+// Capability Detection Tests
+// =============================================================================
+
+func TestClientSupportsSampling_WithSamplingCapability(t *testing.T) {
+	session := &mockSession{supportsSampling: true}
+	assert.True(t, provider.ClientSupportsSampling(session))
+}
+
+func TestClientSupportsSampling_WithoutSamplingCapability(t *testing.T) {
+	session := &mockSession{supportsSampling: false}
+	assert.False(t, provider.ClientSupportsSampling(session))
+}
+
+func TestClientSupportsSampling_NilSession(t *testing.T) {
+	assert.False(t, provider.ClientSupportsSampling(nil))
+}
+
+func TestClientSupportsSampling_NilCapabilities(t *testing.T) {
+	session := &mockSession{
+		initializeParams: &mcp.InitializeParams{
+			Capabilities: nil,
+		},
+	}
+	assert.False(t, provider.ClientSupportsSampling(session))
+}
+
+func TestClientSupportsSampling_NilInitializeParams(t *testing.T) {
+	session := &mockSession{
+		initializeParams: nil,
+	}
+	// When initializeParams returns nil explicitly
+	session.initializeParams = nil
+	// Need to override the default behavior
+	assert.False(t, provider.ClientSupportsSampling(&nilParamsSession{}))
+}
+
+type nilParamsSession struct{}
+
+func (n *nilParamsSession) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+	return nil, nil
+}
+
+func (n *nilParamsSession) InitializeParams() *mcp.InitializeParams {
+	return nil
+}
+
+// =============================================================================
+// Sampling Provider Creation Tests
+// =============================================================================
+
+func TestFactory_CreateSamplingProvider_Success(t *testing.T) {
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	session := &mockSession{supportsSampling: true}
+	provider, err := factory.CreateSamplingProvider(session)
+
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+}
+
+func TestFactory_CreateSamplingProvider_NilSession(t *testing.T) {
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	_, err := factory.CreateSamplingProvider(nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session")
+}
+
+func TestFactory_CreateSamplingProvider_NoSamplingSupport(t *testing.T) {
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	session := &mockSession{supportsSampling: false}
+	_, err := factory.CreateSamplingProvider(session)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sampling")
+}
+
+// =============================================================================
+// Effective Providers Tests
+// =============================================================================
+
+func TestFactory_EffectiveProviders_DirectProvidersAvailable(t *testing.T) {
+	// Set up test environment with an API key
+	originalKey := os.Getenv("ANTHROPIC_API_KEY")
+	defer os.Setenv("ANTHROPIC_API_KEY", originalKey)
+	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	// Even with sampling support, should prefer direct providers
+	session := &mockSession{supportsSampling: true}
+	providers, err := factory.EffectiveProviders(session)
+
+	require.NoError(t, err)
+	assert.Len(t, providers, 1)
+	assert.Contains(t, providers, "anthropic")
+	// Should NOT contain sampling since direct is available
+	assert.NotContains(t, providers, "sampling")
+}
+
+func TestFactory_EffectiveProviders_FallbackToSampling(t *testing.T) {
+	// Clear API keys
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	session := &mockSession{supportsSampling: true}
+	providers, err := factory.EffectiveProviders(session)
+
+	require.NoError(t, err)
+	assert.Len(t, providers, 1)
+	assert.Contains(t, providers, "sampling")
+}
+
+func TestFactory_EffectiveProviders_NoProvidersAvailable(t *testing.T) {
+	// Clear API keys
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	// No sampling support either
+	session := &mockSession{supportsSampling: false}
+	_, err := factory.EffectiveProviders(session)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no providers available")
+}
+
+func TestFactory_EffectiveProviders_NilSession_NoDirectProviders(t *testing.T) {
+	// Clear API keys
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	_, err := factory.EffectiveProviders(nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no providers available")
+}
+
+func TestFactory_EffectiveProviders_NilSession_DirectProvidersAvailable(t *testing.T) {
+	// Set up test environment with an API key
+	originalKey := os.Getenv("ANTHROPIC_API_KEY")
+	defer os.Setenv("ANTHROPIC_API_KEY", originalKey)
+	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	// Nil session but direct providers available - should work
+	providers, err := factory.EffectiveProviders(nil)
+
+	require.NoError(t, err)
+	assert.Len(t, providers, 1)
+	assert.Contains(t, providers, "anthropic")
+}
+
+// =============================================================================
+// Interface Verification Tests
+// =============================================================================
+
+func TestFactory_SamplingProvider_ImplementsInterface(t *testing.T) {
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("OPENAI_API_KEY")
+
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{},
+	})
+
+	session := &mockSession{supportsSampling: true}
+	provider, err := factory.CreateSamplingProvider(session)
+
+	require.NoError(t, err)
+	// Verify it implements review.Provider
+	var _ review.Provider = provider
+}

--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bkyoung/code-reviewer/internal/adapter/llm/sampling"
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/provider"
 	"github.com/bkyoung/code-reviewer/internal/domain"
 	"github.com/bkyoung/code-reviewer/internal/usecase/review"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -169,11 +169,7 @@ Use this for:
 }
 
 func (s *Server) handleReviewPR(ctx context.Context, req *mcp.CallToolRequest, input ReviewPRInput) (*mcp.CallToolResult, ReviewPROutput, error) {
-	if s.deps.PRReviewer == nil {
-		return notImplementedResult("review_pr - PRReviewer not configured"), ReviewPROutput{}, nil
-	}
-
-	// Validate inputs
+	// Validate inputs first (before checking dependencies)
 	if input.Owner == "" {
 		return &mcp.CallToolResult{
 			IsError: true,
@@ -199,6 +195,23 @@ func (s *Server) handleReviewPR(ctx context.Context, req *mcp.CallToolRequest, i
 		}, ReviewPROutput{}, nil
 	}
 
+	// Determine which reviewer to use:
+	// 1. Prefer direct PRReviewer if available (from API keys)
+	// 2. Fall back to per-request orchestrator with factory providers
+	var reviewer PRReviewer = s.deps.PRReviewer
+	if reviewer == nil {
+		// Try to create a per-request orchestrator using the factory
+		perRequestReviewer, err := s.createPerRequestReviewer(req)
+		if err != nil {
+			return notImplementedResult(
+					"review_pr requires either: " +
+						"(1) LLM API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY), or " +
+						"(2) an MCP client that supports sampling"),
+				ReviewPROutput{}, nil
+		}
+		reviewer = perRequestReviewer
+	}
+
 	// Build PRRequest
 	prReq := review.PRRequest{
 		Owner:        input.Owner,
@@ -209,7 +222,7 @@ func (s *Server) handleReviewPR(ctx context.Context, req *mcp.CallToolRequest, i
 	}
 
 	// Invoke review
-	result, err := s.deps.PRReviewer.ReviewPR(ctx, prReq)
+	result, err := reviewer.ReviewPR(ctx, prReq)
 	if err != nil {
 		return nil, ReviewPROutput{}, fmt.Errorf("review PR: %w", err)
 	}
@@ -580,24 +593,19 @@ func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolReques
 
 	// Determine which reviewer to use:
 	// 1. Prefer direct BranchReviewer if available (from API keys)
-	// 2. Fall back to sampling if client supports it
+	// 2. Fall back to per-request orchestrator with factory providers
 	reviewer := s.deps.BranchReviewer
 	if reviewer == nil {
-		// Try to create a sampling-based reviewer
-		var session *mcp.ServerSession
-		if req != nil {
-			session = req.Session
-		}
-		samplingReviewer, err := s.createSamplingReviewer(session)
+		// Try to create a per-request orchestrator using the factory
+		perRequestReviewer, err := s.createPerRequestReviewer(req)
 		if err != nil {
-			// Provide helpful error message based on what's missing
 			return notImplementedResult(
 					"review_branch requires either: " +
 						"(1) LLM API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY), or " +
 						"(2) an MCP client that supports sampling"),
 				ReviewBranchOutput{}, nil
 		}
-		reviewer = samplingReviewer
+		reviewer = perRequestReviewer
 	}
 
 	// Build BranchRequest
@@ -657,16 +665,29 @@ func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolReques
 }
 
 // =============================================================================
-// Sampling Fallback Support
+// Per-Request Reviewer Support
 // =============================================================================
 
-// createSamplingReviewer creates a branch reviewer that uses MCP sampling.
-// It returns an error if:
-// - The session is nil
-// - The client doesn't support sampling
+// Reviewer is the common interface for both branch and PR reviewers.
+// This allows the same per-request creation logic to be used for both tools.
+type Reviewer interface {
+	BranchReviewer
+	PRReviewer
+}
+
+// createPerRequestReviewer creates a reviewer using the provider factory.
+// It uses effective providers (direct or sampling fallback) to create an
+// orchestrator per-request, enabling zero-config usage via MCP sampling.
+//
+// Returns an error if:
+// - The factory is not configured
 // - Required dependencies (Git, Merger) are not configured
-func (s *Server) createSamplingReviewer(session *mcp.ServerSession) (BranchReviewer, error) {
+// - No providers are available (no API keys and no sampling support)
+func (s *Server) createPerRequestReviewer(req *mcp.CallToolRequest) (Reviewer, error) {
 	// Check for required dependencies
+	if s.deps.ProviderFactory == nil {
+		return nil, fmt.Errorf("provider factory not configured")
+	}
 	if s.deps.Git == nil {
 		return nil, fmt.Errorf("git engine not configured")
 	}
@@ -674,27 +695,22 @@ func (s *Server) createSamplingReviewer(session *mcp.ServerSession) (BranchRevie
 		return nil, fmt.Errorf("merger not configured")
 	}
 
-	// Check session availability
-	if session == nil {
-		return nil, fmt.Errorf("no session available")
+	// Get the session from the request (for sampling fallback)
+	var session provider.SamplingSession
+	if req != nil && req.Session != nil {
+		session = &serverSessionAdapter{req.Session}
 	}
 
-	// Check if client supports sampling
-	if !clientSupportsSampling(session) {
-		return nil, fmt.Errorf("client does not support sampling")
+	// Get effective providers from factory (direct or sampling)
+	providers, err := s.deps.ProviderFactory.EffectiveProviders(session)
+	if err != nil {
+		return nil, fmt.Errorf("no providers available: %w", err)
 	}
 
-	// Create sampling provider with session
-	// Note: We capture the session in a closure so the provider can use it
-	sessionProvider := func() sampling.Session {
-		return &serverSessionAdapter{session}
-	}
-	samplingProvider := sampling.NewProvider(sessionProvider)
-
-	// Create orchestrator with sampling provider
+	// Create orchestrator with effective providers
 	orchestrator := review.NewOrchestrator(review.OrchestratorDeps{
 		Git:              s.deps.Git,
-		Providers:        map[string]review.Provider{"sampling": samplingProvider},
+		Providers:        providers,
 		Merger:           s.deps.Merger,
 		ReviewerRegistry: s.deps.ReviewerRegistry,
 	})
@@ -702,25 +718,15 @@ func (s *Server) createSamplingReviewer(session *mcp.ServerSession) (BranchRevie
 	return orchestrator, nil
 }
 
-// clientSupportsSampling checks if the connected MCP client supports sampling.
-// Sampling is indicated by the presence of the sampling capability in client info.
-func clientSupportsSampling(session *mcp.ServerSession) bool {
-	if session == nil {
-		return false
-	}
-	params := session.InitializeParams()
-	if params == nil || params.Capabilities == nil {
-		return false
-	}
-	return params.Capabilities.Sampling != nil
-}
-
-// serverSessionAdapter adapts mcp.ServerSession to sampling.Session interface.
-// This allows the sampling provider to use the MCP session without importing the mcp package.
+// serverSessionAdapter adapts mcp.ServerSession to provider.SamplingSession.
 type serverSessionAdapter struct {
 	session *mcp.ServerSession
 }
 
 func (a *serverSessionAdapter) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
 	return a.session.CreateMessage(ctx, params)
+}
+
+func (a *serverSessionAdapter) InitializeParams() *mcp.InitializeParams {
+	return a.session.InitializeParams()
 }

--- a/internal/adapter/mcp/server.go
+++ b/internal/adapter/mcp/server.go
@@ -3,7 +3,7 @@ package mcp
 import (
 	"context"
 
-	"github.com/bkyoung/code-reviewer/internal/config"
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/provider"
 	"github.com/bkyoung/code-reviewer/internal/domain"
 	"github.com/bkyoung/code-reviewer/internal/usecase/review"
 	"github.com/bkyoung/code-reviewer/internal/usecase/triage"
@@ -78,11 +78,14 @@ type ServerDeps struct {
 	// Optional: only required for review_branch tool when direct API keys are available.
 	BranchReviewer BranchReviewer
 
-	// === Sampling Fallback Dependencies ===
-	// These are used to create a per-request orchestrator when BranchReviewer is nil
-	// but the client supports MCP sampling.
+	// === Provider Factory and Dependencies ===
+	// These support per-request provider creation with sampling fallback.
 
-	// Git provides git operations for branch reviews via sampling fallback.
+	// ProviderFactory creates LLM providers (direct or sampling-based).
+	// Used when BranchReviewer/PRReviewer is nil to create per-request orchestrators.
+	ProviderFactory *provider.Factory
+
+	// Git provides git operations for branch/PR reviews.
 	Git GitEngine
 
 	// Merger merges findings from multiple providers.
@@ -90,9 +93,6 @@ type ServerDeps struct {
 
 	// ReviewerRegistry provides reviewer configurations for persona support.
 	ReviewerRegistry review.ReviewerRegistry
-
-	// Config provides configuration for reviewers and other settings.
-	Config *config.Config
 }
 
 // Server wraps the MCP server and provides triage tools.


### PR DESCRIPTION
## Summary

- Implement the provider factory pattern as originally designed in issues #197-199
- Enable both `review_branch` and `review_pr` tools to use MCP sampling fallback without code duplication
- Correct the shortcuts taken in PR #202 by properly implementing the extensible architecture

## Changes

- Add `internal/adapter/llm/provider` package with `Factory` type
- `Factory.EffectiveProviders()` returns direct or sampling providers based on availability
- `Factory.ClientSupportsSampling()` for capability detection
- `createPerRequestReviewer()` replaces inline `createSamplingReviewer()`
- Both `review_branch` and `review_pr` now use the factory pattern
- Simplify `main.go` by using factory instead of `buildProvidersFromEnv`

## Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│                    Provider Factory                              │
├─────────────────────────────────────────────────────────────────┤
│  DirectProviders()     │  CreateSamplingProvider()              │
│  (from API keys)       │  (from MCP session)                    │
├─────────────────────────────────────────────────────────────────┤
│               EffectiveProviders(session)                        │
│  Returns direct if available, else sampling fallback            │
└─────────────────────────────────────────────────────────────────┘
                              ↓
┌─────────────────────────────────────────────────────────────────┐
│              review_branch / review_pr handlers                  │
│                  createPerRequestReviewer()                      │
└─────────────────────────────────────────────────────────────────┘
```

## Test plan

- [x] 18 factory unit tests covering all code paths
- [x] Existing MCP handler tests pass
- [x] `mage check` passes
- [x] `mage testRace` passes
- [x] `mage buildAll` succeeds

Closes #197
Closes #198
Closes #199