### PR TITLE
test(mcp): add sampling fallback integration tests and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,16 +75,20 @@
 
 | Component | Status |
 |-----------|--------|
+| MCP `review_branch` tool | ✅ Complete |
+| MCP `review_pr` tool | ✅ Complete |
+| MCP `post_findings` tool | ✅ Complete |
+| MCP sampling fallback | ✅ Complete |
 | `cr review pr` command | 🚧 Planned |
 | Session-based local storage | 🚧 Planned |
 | Interactive TUI (Bubble Tea) | 🚧 Planned |
-| MCP `review_pr` / `post_findings` tools | 🚧 Planned |
 
 ### Key Documents
 
 - **Phase 3 PRD:** `docs/design/01-PRD.md`
 - **Phase 3 Architecture:** `docs/design/02-ARCHITECTURE.md`
 - **Phase 3.5 Design:** `docs/design/05-PHASE-3.5-LOCAL-MODE.md`
+- **MCP Sampling Fallback:** `docs/design/06-MCP-SAMPLING-FALLBACK.md`
 - **Security:** `docs/SECURITY.md`
 - **Archived Docs:** `docs/archive/` (roadmaps, TDDs, historical reference)
 
@@ -94,7 +98,7 @@
 
 - **Language:** Go 1.21+
 - **Architecture:** Clean Architecture (domain → usecase → adapter)
-- **LLM Providers:** OpenAI, Anthropic, Gemini, Ollama
+- **LLM Providers:** OpenAI, Anthropic, Gemini, Ollama, MCP Sampling (fallback)
 - **Output Formats:** Markdown, JSON, SARIF
 - **Persistence:** SQLite
 - **Build System:** Mage (preferred)

--- a/docs/design/06-MCP-SAMPLING-FALLBACK.md
+++ b/docs/design/06-MCP-SAMPLING-FALLBACK.md
@@ -1,8 +1,9 @@
 # Phase 3.5e: MCP Sampling Fallback
 
-**Status:** Design
+**Status:** Implemented
 **Author:** Claude (with Brandon)
 **Created:** 2026-01-01
+**Implemented:** 2026-01-02
 **Epic:** #195
 **Sub-issues:** #196, #197, #198, #199, #200
 
@@ -533,15 +534,35 @@ Cache sampling responses for identical diffs to reduce client load.
 
 ---
 
+## Implementation Notes
+
+The implementation followed the design with the following actual file structure:
+
+| File | Description |
+|------|-------------|
+| `internal/adapter/llm/sampling/provider.go` | Sampling-based provider using MCP CreateMessage |
+| `internal/adapter/llm/sampling/provider_test.go` | Unit tests for sampling provider |
+| `internal/adapter/llm/provider/factory.go` | Provider factory (in `provider` subpackage to avoid import cycles) |
+| `internal/adapter/llm/provider/factory_test.go` | Factory unit tests |
+| `internal/adapter/mcp/review_handlers.go` | Per-request orchestrator creation with `createPerRequestReviewer()` |
+| `internal/adapter/mcp/sampling_integration_test.go` | Integration tests for sampling fallback |
+
+**Key implementation decisions:**
+- Factory placed in `internal/adapter/llm/provider/` subpackage to avoid import cycles
+- Both `review_branch` and `review_pr` share the same fallback mechanism via `createPerRequestReviewer()`
+- Tool descriptions updated to document sampling fallback behavior
+
+---
+
 ## Acceptance Criteria
 
-- [ ] `review_branch` works without any API keys when client supports sampling
-- [ ] `review_branch` prefers direct providers when API keys are available
-- [ ] Reviewer personas work via sampling (system prompt passed)
-- [ ] Clear error message when neither API keys nor sampling available
-- [ ] Unit tests for sampling provider
-- [ ] Integration test with mock MCP client
-- [ ] Documentation updated
+- [x] `review_branch` works without any API keys when client supports sampling
+- [x] `review_branch` prefers direct providers when API keys are available
+- [x] Reviewer personas work via sampling (system prompt passed)
+- [x] Clear error message when neither API keys nor sampling available
+- [x] Unit tests for sampling provider
+- [x] Integration test with mock MCP client
+- [x] Documentation updated
 
 ---
 

--- a/internal/adapter/llm/provider/factory_test.go
+++ b/internal/adapter/llm/provider/factory_test.go
@@ -2,7 +2,6 @@ package provider_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/bkyoung/code-reviewer/internal/adapter/llm/provider"
@@ -52,8 +51,8 @@ func (m *mockSession) InitializeParams() *mcp.InitializeParams {
 
 func TestNewFactory_NoProviders(t *testing.T) {
 	// Clear any existing API keys
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -64,11 +63,9 @@ func TestNewFactory_NoProviders(t *testing.T) {
 }
 
 func TestNewFactory_WithAnthropicKey(t *testing.T) {
-	// Set up test environment
-	originalKey := os.Getenv("ANTHROPIC_API_KEY")
-	defer os.Setenv("ANTHROPIC_API_KEY", originalKey)
-	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
-	os.Unsetenv("OPENAI_API_KEY")
+	// Set up test environment using t.Setenv for automatic cleanup
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -80,11 +77,9 @@ func TestNewFactory_WithAnthropicKey(t *testing.T) {
 }
 
 func TestNewFactory_WithOpenAIKey(t *testing.T) {
-	// Set up test environment
-	originalKey := os.Getenv("OPENAI_API_KEY")
-	defer os.Setenv("OPENAI_API_KEY", originalKey)
-	os.Setenv("OPENAI_API_KEY", "test-openai-key")
-	os.Unsetenv("ANTHROPIC_API_KEY")
+	// Set up test environment using t.Setenv for automatic cleanup
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+	t.Setenv("ANTHROPIC_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -96,15 +91,9 @@ func TestNewFactory_WithOpenAIKey(t *testing.T) {
 }
 
 func TestNewFactory_WithBothKeys(t *testing.T) {
-	// Set up test environment
-	originalAnthropicKey := os.Getenv("ANTHROPIC_API_KEY")
-	originalOpenAIKey := os.Getenv("OPENAI_API_KEY")
-	defer func() {
-		os.Setenv("ANTHROPIC_API_KEY", originalAnthropicKey)
-		os.Setenv("OPENAI_API_KEY", originalOpenAIKey)
-	}()
-	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
-	os.Setenv("OPENAI_API_KEY", "test-openai-key")
+	// Set up test environment using t.Setenv for automatic cleanup
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -168,18 +157,18 @@ func (n *nilParamsSession) InitializeParams() *mcp.InitializeParams {
 // =============================================================================
 
 func TestFactory_CreateSamplingProvider_Success(t *testing.T) {
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
 	})
 
 	session := &mockSession{supportsSampling: true}
-	provider, err := factory.CreateSamplingProvider(session)
+	p, err := factory.CreateSamplingProvider(session)
 
 	require.NoError(t, err)
-	assert.NotNil(t, provider)
+	assert.NotNil(t, p)
 }
 
 func TestFactory_CreateSamplingProvider_NilSession(t *testing.T) {
@@ -210,11 +199,9 @@ func TestFactory_CreateSamplingProvider_NoSamplingSupport(t *testing.T) {
 // =============================================================================
 
 func TestFactory_EffectiveProviders_DirectProvidersAvailable(t *testing.T) {
-	// Set up test environment with an API key
-	originalKey := os.Getenv("ANTHROPIC_API_KEY")
-	defer os.Setenv("ANTHROPIC_API_KEY", originalKey)
-	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
-	os.Unsetenv("OPENAI_API_KEY")
+	// Set up test environment with an API key using t.Setenv for automatic cleanup
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -233,8 +220,8 @@ func TestFactory_EffectiveProviders_DirectProvidersAvailable(t *testing.T) {
 
 func TestFactory_EffectiveProviders_FallbackToSampling(t *testing.T) {
 	// Clear API keys
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -250,8 +237,8 @@ func TestFactory_EffectiveProviders_FallbackToSampling(t *testing.T) {
 
 func TestFactory_EffectiveProviders_NoProvidersAvailable(t *testing.T) {
 	// Clear API keys
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -267,8 +254,8 @@ func TestFactory_EffectiveProviders_NoProvidersAvailable(t *testing.T) {
 
 func TestFactory_EffectiveProviders_NilSession_NoDirectProviders(t *testing.T) {
 	// Clear API keys
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -281,10 +268,9 @@ func TestFactory_EffectiveProviders_NilSession_NoDirectProviders(t *testing.T) {
 }
 
 func TestFactory_EffectiveProviders_NilSession_DirectProvidersAvailable(t *testing.T) {
-	// Set up test environment with an API key
-	originalKey := os.Getenv("ANTHROPIC_API_KEY")
-	defer os.Setenv("ANTHROPIC_API_KEY", originalKey)
-	os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	// Set up test environment with an API key using t.Setenv for automatic cleanup
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
@@ -303,17 +289,17 @@ func TestFactory_EffectiveProviders_NilSession_DirectProvidersAvailable(t *testi
 // =============================================================================
 
 func TestFactory_SamplingProvider_ImplementsInterface(t *testing.T) {
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	factory := provider.NewFactory(provider.FactoryOptions{
 		Config: &config.Config{},
 	})
 
 	session := &mockSession{supportsSampling: true}
-	provider, err := factory.CreateSamplingProvider(session)
+	p, err := factory.CreateSamplingProvider(session)
 
 	require.NoError(t, err)
 	// Verify it implements review.Provider
-	var _ review.Provider = provider
+	_ = review.Provider(p)
 }

--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -161,6 +161,9 @@ func (s *Server) registerReviewPRTool() {
 This tool invokes code reviewers on a PR's diff and returns findings WITHOUT posting to GitHub.
 The caller can then filter/modify findings using edit_finding and post selected ones using post_findings.
 
+Uses configured LLM providers (via ANTHROPIC_API_KEY or OPENAI_API_KEY).
+Falls back to MCP sampling if no API keys configured and client supports it.
+
 Use this for:
 - Running code review on any accessible PR
 - Getting findings for human review before posting
@@ -198,7 +201,7 @@ func (s *Server) handleReviewPR(ctx context.Context, req *mcp.CallToolRequest, i
 	// Determine which reviewer to use:
 	// 1. Prefer direct PRReviewer if available (from API keys)
 	// 2. Fall back to per-request orchestrator with factory providers
-	var reviewer PRReviewer = s.deps.PRReviewer
+	reviewer := s.deps.PRReviewer
 	if reviewer == nil {
 		// Try to create a per-request orchestrator using the factory
 		perRequestReviewer, err := s.createPerRequestReviewer(req)
@@ -572,6 +575,9 @@ func (s *Server) registerReviewBranchTool() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "review_branch",
 		Description: `Review a local git branch against a base reference. Returns findings without posting to any remote service.
+
+Uses configured LLM providers (via ANTHROPIC_API_KEY or OPENAI_API_KEY).
+Falls back to MCP sampling if no API keys configured and client supports it.
 
 Use this for:
 - Running code review on local changes before pushing

--- a/internal/adapter/mcp/sampling_integration_test.go
+++ b/internal/adapter/mcp/sampling_integration_test.go
@@ -1,0 +1,399 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bkyoung/code-reviewer/internal/adapter/llm/provider"
+	"github.com/bkyoung/code-reviewer/internal/config"
+	"github.com/bkyoung/code-reviewer/internal/usecase/review"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// =============================================================================
+// Mock Implementations for Sampling Integration Tests
+// =============================================================================
+
+// mockSamplingSession implements provider.SamplingSession for testing.
+type mockSamplingSession struct {
+	createMessageFunc func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error)
+	supportsSampling  bool
+}
+
+func (m *mockSamplingSession) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+	if m.createMessageFunc != nil {
+		return m.createMessageFunc(ctx, params)
+	}
+	// Default: return a valid review response
+	return &mcp.CreateMessageResult{
+		Content: &mcp.TextContent{Text: `{"summary": "test review", "findings": [{"file": "main.go", "line_start": 10, "line_end": 10, "severity": "medium", "category": "bug", "description": "Test finding from sampling"}]}`},
+		Model:   "claude-3-5-sonnet",
+	}, nil
+}
+
+func (m *mockSamplingSession) InitializeParams() *mcp.InitializeParams {
+	if m.supportsSampling {
+		return &mcp.InitializeParams{
+			Capabilities: &mcp.ClientCapabilities{
+				Sampling: &mcp.SamplingCapabilities{},
+			},
+		}
+	}
+	return &mcp.InitializeParams{
+		Capabilities: &mcp.ClientCapabilities{},
+	}
+}
+
+// =============================================================================
+// Integration Tests: Sampling Fallback Behavior
+// =============================================================================
+
+func TestIntegration_SamplingFallback_FactoryBehavior(t *testing.T) {
+	// Save and clear environment for consistent testing
+	origAnthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+	origOpenAIKey := os.Getenv("OPENAI_API_KEY")
+
+	t.Run("creates sampling provider when no API keys", func(t *testing.T) {
+		// Temporarily clear API keys
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("OPENAI_API_KEY", "")
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		// Verify factory has no direct providers
+		require.Empty(t, factory.DirectProviders(), "expected no direct providers when API keys are cleared")
+
+		// Create a mock session with sampling support
+		mockSession := &mockSamplingSession{
+			supportsSampling: true,
+			createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+				return &mcp.CreateMessageResult{
+					Content: &mcp.TextContent{Text: `{"summary": "test", "findings": []}`},
+					Model:   "claude-3-5-sonnet",
+				}, nil
+			},
+		}
+
+		// Should be able to create sampling provider
+		samplingProvider, err := factory.CreateSamplingProvider(mockSession)
+		require.NoError(t, err)
+		require.NotNil(t, samplingProvider)
+
+		// EffectiveProviders should return sampling
+		providers, err := factory.EffectiveProviders(mockSession)
+		require.NoError(t, err)
+		assert.Len(t, providers, 1)
+		assert.Contains(t, providers, "sampling")
+	})
+
+	t.Run("prefers direct providers over sampling when API keys present", func(t *testing.T) {
+		// Skip if we actually have API keys (we'll test with mock factory behavior)
+		if origAnthropicKey != "" || origOpenAIKey != "" {
+			// Test the behavior: when HasDirectProviders returns true, sampling is not used
+			factory := provider.NewFactory(provider.FactoryOptions{
+				Config: &config.Config{},
+			})
+
+			mockSession := &mockSamplingSession{supportsSampling: true}
+
+			// Since we have API keys, EffectiveProviders should return direct providers
+			providers, err := factory.EffectiveProviders(mockSession)
+			require.NoError(t, err)
+
+			// Should NOT contain sampling when direct providers available
+			assert.NotContains(t, providers, "sampling")
+			// Should contain at least one direct provider
+			assert.True(t, len(providers) > 0, "expected at least one direct provider")
+		} else {
+			t.Skip("Skipping test - requires API keys in environment to test priority")
+		}
+	})
+
+	t.Run("returns error when no providers available", func(t *testing.T) {
+		// Temporarily clear API keys
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("OPENAI_API_KEY", "")
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		// Session without sampling support
+		mockSession := &mockSamplingSession{supportsSampling: false}
+
+		_, err := factory.EffectiveProviders(mockSession)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no providers available")
+	})
+
+	t.Run("returns error for nil session without direct providers", func(t *testing.T) {
+		// Temporarily clear API keys
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("OPENAI_API_KEY", "")
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		_, err := factory.EffectiveProviders(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no providers available")
+	})
+}
+
+func TestIntegration_CapabilityDetection(t *testing.T) {
+	t.Run("detects sampling capability from session", func(t *testing.T) {
+		sessionWithSampling := &mockSamplingSession{supportsSampling: true}
+		assert.True(t, provider.ClientSupportsSampling(sessionWithSampling))
+	})
+
+	t.Run("detects missing sampling capability", func(t *testing.T) {
+		sessionWithoutSampling := &mockSamplingSession{supportsSampling: false}
+		assert.False(t, provider.ClientSupportsSampling(sessionWithoutSampling))
+	})
+
+	t.Run("handles nil session gracefully", func(t *testing.T) {
+		assert.False(t, provider.ClientSupportsSampling(nil))
+	})
+}
+
+func TestIntegration_SamplingProvider_ResponseParsing(t *testing.T) {
+	// Save and clear environment for consistent testing
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	t.Run("parses valid JSON review response", func(t *testing.T) {
+		mockSession := &mockSamplingSession{
+			supportsSampling: true,
+			createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+				return &mcp.CreateMessageResult{
+					Content: &mcp.TextContent{Text: `{
+						"summary": "Found potential issues",
+						"findings": [
+							{
+								"file": "main.go",
+								"line_start": 42,
+								"line_end": 45,
+								"severity": "high",
+								"category": "security",
+								"description": "SQL injection vulnerability"
+							},
+							{
+								"file": "utils.go",
+								"line_start": 10,
+								"line_end": 10,
+								"severity": "medium",
+								"category": "bug",
+								"description": "Potential nil pointer"
+							}
+						]
+					}`},
+					Model: "claude-3-5-sonnet",
+				}, nil
+			},
+		}
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		samplingProvider, err := factory.CreateSamplingProvider(mockSession)
+		require.NoError(t, err)
+
+		// Perform a review request
+		result, err := samplingProvider.Review(context.Background(), review.ProviderRequest{
+			Prompt:  "Review this code",
+			MaxSize: 4096,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "sampling", result.ProviderName)
+		assert.Equal(t, "claude-3-5-sonnet", result.ModelName)
+		assert.Len(t, result.Findings, 2)
+		assert.Equal(t, "main.go", result.Findings[0].File)
+		assert.Equal(t, "high", result.Findings[0].Severity)
+	})
+
+	t.Run("parses markdown-wrapped JSON response", func(t *testing.T) {
+		mockSession := &mockSamplingSession{
+			supportsSampling: true,
+			createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+				return &mcp.CreateMessageResult{
+					Content: &mcp.TextContent{Text: "```json\n{\"summary\": \"test\", \"findings\": [{\"file\": \"test.go\", \"line_start\": 1, \"line_end\": 1, \"severity\": \"low\", \"category\": \"style\", \"description\": \"minor issue\"}]}\n```"},
+					Model:   "claude-3-5-sonnet",
+				}, nil
+			},
+		}
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		samplingProvider, err := factory.CreateSamplingProvider(mockSession)
+		require.NoError(t, err)
+
+		result, err := samplingProvider.Review(context.Background(), review.ProviderRequest{
+			Prompt:  "Review this code",
+			MaxSize: 4096,
+		})
+		require.NoError(t, err)
+
+		assert.Len(t, result.Findings, 1)
+		assert.Equal(t, "test.go", result.Findings[0].File)
+	})
+
+	t.Run("handles empty findings array", func(t *testing.T) {
+		mockSession := &mockSamplingSession{
+			supportsSampling: true,
+			createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+				return &mcp.CreateMessageResult{
+					Content: &mcp.TextContent{Text: `{"summary": "No issues found", "findings": []}`},
+					Model:   "claude-3-5-sonnet",
+				}, nil
+			},
+		}
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		samplingProvider, err := factory.CreateSamplingProvider(mockSession)
+		require.NoError(t, err)
+
+		result, err := samplingProvider.Review(context.Background(), review.ProviderRequest{
+			Prompt:  "Review this code",
+			MaxSize: 4096,
+		})
+		require.NoError(t, err)
+
+		assert.Empty(t, result.Findings)
+		assert.Equal(t, "No issues found", result.Summary)
+	})
+
+	t.Run("handles camelCase field names", func(t *testing.T) {
+		mockSession := &mockSamplingSession{
+			supportsSampling: true,
+			createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+				return &mcp.CreateMessageResult{
+					Content: &mcp.TextContent{Text: `{"summary": "test", "findings": [{"file": "main.go", "lineStart": 10, "lineEnd": 10, "severity": "high", "category": "bug", "description": "test"}]}`},
+					Model:   "claude-3-5-sonnet",
+				}, nil
+			},
+		}
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		samplingProvider, err := factory.CreateSamplingProvider(mockSession)
+		require.NoError(t, err)
+
+		result, err := samplingProvider.Review(context.Background(), review.ProviderRequest{
+			Prompt:  "Review this code",
+			MaxSize: 4096,
+		})
+		require.NoError(t, err)
+
+		// The parser should handle both camelCase and snake_case
+		assert.Len(t, result.Findings, 1)
+		assert.Equal(t, 10, result.Findings[0].LineStart)
+	})
+}
+
+func TestIntegration_SamplingProvider_ErrorHandling(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	t.Run("returns error for invalid JSON response", func(t *testing.T) {
+		mockSession := &mockSamplingSession{
+			supportsSampling: true,
+			createMessageFunc: func(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+				return &mcp.CreateMessageResult{
+					Content: &mcp.TextContent{Text: `not valid json`},
+					Model:   "claude-3-5-sonnet",
+				}, nil
+			},
+		}
+
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		samplingProvider, err := factory.CreateSamplingProvider(mockSession)
+		require.NoError(t, err)
+
+		_, err = samplingProvider.Review(context.Background(), review.ProviderRequest{
+			Prompt:  "Review this code",
+			MaxSize: 4096,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse")
+	})
+}
+
+func TestIntegration_HandlerErrorMessages(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	t.Run("review_branch shows helpful error when no providers", func(t *testing.T) {
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		server := NewServer(ServerDeps{
+			ProviderFactory: factory,
+			// Git, Merger not set - simulates minimal setup
+		})
+
+		input := ReviewBranchInput{
+			BaseRef: "main",
+		}
+
+		// Call handler directly with nil request (no session)
+		result, _, err := server.handleReviewBranch(context.Background(), nil, input)
+
+		// The handler should return a result with IsError, not an error
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+
+		// Check error message is helpful
+		textContent, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "LLM API keys")
+		assert.Contains(t, textContent.Text, "sampling")
+	})
+
+	t.Run("review_pr shows helpful error when no providers", func(t *testing.T) {
+		factory := provider.NewFactory(provider.FactoryOptions{
+			Config: &config.Config{},
+		})
+
+		server := NewServer(ServerDeps{
+			ProviderFactory: factory,
+		})
+
+		input := ReviewPRInput{
+			Owner:    "owner",
+			Repo:     "repo",
+			PRNumber: 123,
+		}
+
+		result, _, err := server.handleReviewPR(context.Background(), nil, input)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+
+		textContent, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "LLM API keys")
+		assert.Contains(t, textContent.Text, "sampling")
+	})
+}


### PR DESCRIPTION
## Summary
- Add comprehensive integration tests for MCP sampling fallback behavior
- Update tool descriptions to document fallback mechanism
- Mark design doc as implemented with implementation notes
- Fix test isolation by using `t.Setenv` for environment variables

Closes #200

## Changes

### New Tests (`internal/adapter/mcp/sampling_integration_test.go`)
- **Factory Fallback Behavior**: Tests that factory creates sampling provider when no API keys configured
- **Capability Detection**: Verifies correct detection of MCP sampling capability
- **Response Parsing**: Tests JSON and markdown-wrapped response handling
- **Error Handling**: Validates error messages for missing providers

### Documentation Updates
- `docs/design/06-MCP-SAMPLING-FALLBACK.md`: Marked as implemented, added implementation notes
- `CLAUDE.md`: Added reference to sampling fallback design doc

### Tool Description Updates
- `review_branch` and `review_pr` now mention MCP sampling fallback

### Test Improvements
- Replaced `os.Setenv`/`os.Unsetenv` with `t.Setenv` for proper test isolation
- Fixed lint errors in factory_test.go

## Test plan
- [x] `mage lint` passes
- [x] `mage test` passes
- [x] `mage testRace` passes
- [x] `mage buildAll` succeeds