### PR TITLE
fix(provider): return defensive copies from factory map getters

### DIFF
--- a/internal/adapter/llm/provider/factory.go
+++ b/internal/adapter/llm/provider/factory.go
@@ -91,10 +91,15 @@ func (f *Factory) buildDirectProviders() {
 	}
 }
 
-// DirectProviders returns the providers built from API keys.
+// DirectProviders returns a copy of the providers built from API keys.
 // Returns an empty map if no API keys were configured.
+// The returned map is a defensive copy safe for external modification.
 func (f *Factory) DirectProviders() map[string]review.Provider {
-	return f.directProviders
+	result := make(map[string]review.Provider, len(f.directProviders))
+	for k, v := range f.directProviders {
+		result[k] = v
+	}
+	return result
 }
 
 // HasDirectProviders returns true if any direct providers are available.
@@ -129,10 +134,11 @@ func (f *Factory) CreateSamplingProvider(session SamplingSession) (review.Provid
 //  2. Sampling provider (from MCP session) - used as fallback when no API keys
 //
 // Returns an error if no providers are available (no API keys and no sampling support).
+// The returned map is a defensive copy safe for external modification.
 func (f *Factory) EffectiveProviders(session SamplingSession) (map[string]review.Provider, error) {
 	// Prefer direct providers
 	if f.HasDirectProviders() {
-		return f.directProviders, nil
+		return f.DirectProviders(), nil
 	}
 
 	// Fall back to sampling

--- a/internal/adapter/llm/provider/factory_test.go
+++ b/internal/adapter/llm/provider/factory_test.go
@@ -133,15 +133,14 @@ func TestClientSupportsSampling_NilCapabilities(t *testing.T) {
 }
 
 func TestClientSupportsSampling_NilInitializeParams(t *testing.T) {
-	session := &mockSession{
-		initializeParams: nil,
-	}
-	// When initializeParams returns nil explicitly
-	session.initializeParams = nil
-	// Need to override the default behavior
-	assert.False(t, provider.ClientSupportsSampling(&nilParamsSession{}))
+	// nilParamsSession returns nil from InitializeParams(), unlike mockSession
+	// which returns an empty InitializeParams when initializeParams field is nil
+	session := &nilParamsSession{}
+	assert.False(t, provider.ClientSupportsSampling(session))
 }
 
+// nilParamsSession is a session that returns nil from InitializeParams().
+// This is distinct from mockSession which returns an empty InitializeParams.
 type nilParamsSession struct{}
 
 func (n *nilParamsSession) CreateMessage(ctx context.Context, params *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {

--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -685,6 +685,12 @@ type Reviewer interface {
 // It uses effective providers (direct or sampling fallback) to create an
 // orchestrator per-request, enabling zero-config usage via MCP sampling.
 //
+// Thread Safety:
+// This function is safe for concurrent calls. It only reads from immutable
+// Server.deps fields (set at construction), EffectiveProviders returns a
+// defensive copy of the provider map, and a new Orchestrator is created
+// for each request with no shared mutable state.
+//
 // Returns an error if:
 // - The factory is not configured
 // - Required dependencies (Git, Merger) are not configured


### PR DESCRIPTION
## Summary

- Return defensive copies from `DirectProviders()` and `EffectiveProviders()` to prevent external mutation of internal provider map
- Clean up dead test code in `TestClientSupportsSampling_NilInitializeParams`
- Add thread safety documentation for `createPerRequestReviewer()`

## Test plan

- [x] `mage format` - code formatted
- [x] `mage lint` - no lint errors
- [x] `mage test` - all tests pass
- [x] `mage testRace` - no race conditions
- [x] `mage buildAll` - builds successfully

Closes #204