### PR TITLE
fix(mcp): initialize maps in error output to prevent schema validation failure

### DIFF
--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -210,7 +210,12 @@ func (s *Server) handleReviewPR(ctx context.Context, req *mcp.CallToolRequest, i
 					"review_pr requires either: " +
 						"(1) LLM API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY), or " +
 						"(2) an MCP client that supports sampling"),
-				ReviewPROutput{}, nil
+				ReviewPROutput{
+					Findings:      []FindingOutput{},
+					BySeverity:    make(map[string]int),
+					ByCategory:    make(map[string]int),
+					ReviewerStats: []ReviewerStat{},
+				}, nil
 		}
 		reviewer = perRequestReviewer
 	}
@@ -609,7 +614,12 @@ func (s *Server) handleReviewBranch(ctx context.Context, req *mcp.CallToolReques
 					"review_branch requires either: " +
 						"(1) LLM API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY), or " +
 						"(2) an MCP client that supports sampling"),
-				ReviewBranchOutput{}, nil
+				ReviewBranchOutput{
+					Findings:      []FindingOutput{},
+					BySeverity:    make(map[string]int),
+					ByCategory:    make(map[string]int),
+					ReviewerStats: []ReviewerStat{},
+				}, nil
 		}
 		reviewer = perRequestReviewer
 	}

--- a/internal/adapter/mcp/review_handlers_test.go
+++ b/internal/adapter/mcp/review_handlers_test.go
@@ -312,6 +312,12 @@ func TestHandleReviewPR(t *testing.T) {
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
 		assert.Empty(t, output.Findings)
+
+		// Verify output has properly initialized maps (not nil) for schema validation
+		assert.NotNil(t, output.BySeverity, "BySeverity should be initialized, not nil")
+		assert.NotNil(t, output.ByCategory, "ByCategory should be initialized, not nil")
+		assert.NotNil(t, output.Findings, "Findings should be initialized, not nil")
+		assert.NotNil(t, output.ReviewerStats, "ReviewerStats should be initialized, not nil")
 	})
 
 	t.Run("validates required inputs", func(t *testing.T) {
@@ -981,6 +987,12 @@ func TestHandleReviewBranch(t *testing.T) {
 		require.True(t, ok)
 		assert.Contains(t, textContent.Text, "LLM API keys")
 		assert.Contains(t, textContent.Text, "sampling")
+
+		// Verify output has properly initialized maps (not nil) for schema validation
+		assert.NotNil(t, output.BySeverity, "BySeverity should be initialized, not nil")
+		assert.NotNil(t, output.ByCategory, "ByCategory should be initialized, not nil")
+		assert.NotNil(t, output.Findings, "Findings should be initialized, not nil")
+		assert.NotNil(t, output.ReviewerStats, "ReviewerStats should be initialized, not nil")
 	})
 
 	t.Run("validates required base_ref", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix MCP schema validation error when review tools return error responses
- Initialize all map and slice fields in error outputs

## Problem
Error paths in `review_pr` and `review_branch` handlers returned empty struct literals with nil maps. MCP schema validation requires objects (not null) for map fields like `by_severity` and `by_category`, causing:
```
validating /properties/by_severity: type: has type "null", want "object"
```

## Solution
Initialize all map and slice fields in error output structs:
- `BySeverity: make(map[string]int)`
- `ByCategory: make(map[string]int)`
- `Findings: []FindingOutput{}`
- `ReviewerStats: []ReviewerStat{}`

## Test plan
- [x] Added assertions to existing error path tests verifying maps are non-nil
- [x] `mage lint` passes
- [x] `mage test` passes