### PR TITLE
fix(provider): support keyless providers like Ollama in factory

### DIFF
--- a/internal/adapter/llm/provider/factory.go
+++ b/internal/adapter/llm/provider/factory.go
@@ -26,6 +26,22 @@ type SamplingSession interface {
 	InitializeParams() *mcp.InitializeParams
 }
 
+// providerMeta holds metadata about each supported LLM provider.
+// This enables provider-specific behavior like keyless authentication.
+type providerMeta struct {
+	requiresAPIKey bool
+	defaultModel   string
+}
+
+// providerMetadata defines characteristics for each supported provider.
+// Keyless providers (like Ollama) can be enabled without an API key.
+var providerMetadata = map[string]providerMeta{
+	"openai":    {requiresAPIKey: true, defaultModel: "gpt-5.2"},
+	"anthropic": {requiresAPIKey: true, defaultModel: "claude-sonnet-4-5"},
+	"gemini":    {requiresAPIKey: true, defaultModel: "gemini-3-pro-preview"},
+	"ollama":    {requiresAPIKey: false, defaultModel: "codellama"},
+}
+
 // FactoryOptions configures the provider factory.
 type FactoryOptions struct {
 	// Config provides provider-specific settings (models, timeouts, etc.)
@@ -67,10 +83,10 @@ func (f *Factory) buildDirectProviders() {
 	}
 
 	// OpenAI provider
-	if cfg, ok := f.config.Providers["openai"]; ok && isProviderEnabled(cfg) {
+	if cfg, ok := f.config.Providers["openai"]; ok && isProviderEnabled("openai", cfg) {
 		model := cfg.GetDefaultModel()
 		if model == "" {
-			model = "gpt-5.2"
+			model = providerMetadata["openai"].defaultModel
 		}
 		apiKey := cfg.APIKey
 		if apiKey != "" {
@@ -80,10 +96,10 @@ func (f *Factory) buildDirectProviders() {
 	}
 
 	// Anthropic provider
-	if cfg, ok := f.config.Providers["anthropic"]; ok && isProviderEnabled(cfg) {
+	if cfg, ok := f.config.Providers["anthropic"]; ok && isProviderEnabled("anthropic", cfg) {
 		model := cfg.GetDefaultModel()
 		if model == "" {
-			model = "claude-sonnet-4-5"
+			model = providerMetadata["anthropic"].defaultModel
 		}
 		apiKey := cfg.APIKey
 		if apiKey != "" {
@@ -93,10 +109,10 @@ func (f *Factory) buildDirectProviders() {
 	}
 
 	// Gemini provider
-	if cfg, ok := f.config.Providers["gemini"]; ok && isProviderEnabled(cfg) {
+	if cfg, ok := f.config.Providers["gemini"]; ok && isProviderEnabled("gemini", cfg) {
 		model := cfg.GetDefaultModel()
 		if model == "" {
-			model = "gemini-3-pro-preview"
+			model = providerMetadata["gemini"].defaultModel
 		}
 		apiKey := cfg.APIKey
 		if apiKey != "" {
@@ -105,11 +121,11 @@ func (f *Factory) buildDirectProviders() {
 		}
 	}
 
-	// Ollama provider (local LLM)
-	if cfg, ok := f.config.Providers["ollama"]; ok && isProviderEnabled(cfg) {
+	// Ollama provider (local LLM, no API key required)
+	if cfg, ok := f.config.Providers["ollama"]; ok && isProviderEnabled("ollama", cfg) {
 		model := cfg.GetDefaultModel()
 		if model == "" {
-			model = "codellama"
+			model = providerMetadata["ollama"].defaultModel
 		}
 		host := os.Getenv("OLLAMA_HOST")
 		if host == "" {
@@ -120,15 +136,31 @@ func (f *Factory) buildDirectProviders() {
 	}
 }
 
-// isProviderEnabled checks if a provider should be enabled based on its config.
-// A provider is enabled if:
+// isProviderEnabled checks if a provider should be enabled based on its config
+// and provider metadata. A provider is enabled if:
 //   - Enabled is explicitly true, OR
-//   - Enabled is nil (not set) AND APIKey is non-empty
-func isProviderEnabled(cfg config.ProviderConfig) bool {
+//   - Enabled is nil (not set) AND:
+//   - For providers requiring API keys: APIKey is non-empty
+//   - For keyless providers (e.g., Ollama): always enabled when in config
+func isProviderEnabled(providerName string, cfg config.ProviderConfig) bool {
+	// Explicit enabled/disabled takes precedence
 	if cfg.Enabled != nil {
 		return *cfg.Enabled
 	}
-	return cfg.APIKey != ""
+
+	// Check if this provider requires an API key
+	meta, known := providerMetadata[providerName]
+	if !known {
+		// Unknown providers require API key by default (safe fallback)
+		return cfg.APIKey != ""
+	}
+
+	if meta.requiresAPIKey {
+		return cfg.APIKey != ""
+	}
+
+	// Keyless provider: enabled by presence in config
+	return true
 }
 
 // DirectProviders returns a copy of the providers built from API keys.

--- a/internal/adapter/llm/provider/factory_test.go
+++ b/internal/adapter/llm/provider/factory_test.go
@@ -303,3 +303,68 @@ func TestFactory_SamplingProvider_ImplementsInterface(t *testing.T) {
 	// Verify it implements review.Provider
 	_ = review.Provider(p)
 }
+
+// =============================================================================
+// Keyless Provider Tests (Issue #212)
+// =============================================================================
+
+func TestNewFactory_OllamaWithExplicitEnabled(t *testing.T) {
+	enabled := true
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"ollama": {Enabled: &enabled, DefaultModel: "codellama"},
+			},
+		},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Len(t, providers, 1)
+	assert.Contains(t, providers, "ollama")
+}
+
+func TestNewFactory_OllamaWithImplicitEnabled(t *testing.T) {
+	// When Ollama config is present without explicit enabled: true,
+	// it should still be enabled since Ollama doesn't require an API key.
+	// This is the bug fix for issue #212.
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"ollama": {DefaultModel: "codellama"}, // No APIKey, no Enabled
+			},
+		},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Len(t, providers, 1, "Ollama should be enabled implicitly when config is present")
+	assert.Contains(t, providers, "ollama")
+}
+
+func TestNewFactory_OllamaExplicitlyDisabled(t *testing.T) {
+	enabled := false
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"ollama": {Enabled: &enabled, DefaultModel: "codellama"},
+			},
+		},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Empty(t, providers, "Ollama should not be enabled when explicitly disabled")
+}
+
+func TestNewFactory_KeyRequiredProvidersStillNeedKeys(t *testing.T) {
+	// Providers that require API keys should still fail without them
+	factory := provider.NewFactory(provider.FactoryOptions{
+		Config: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"anthropic": {DefaultModel: "claude-sonnet-4-5"}, // No APIKey
+				"openai":    {DefaultModel: "gpt-4o"},            // No APIKey
+			},
+		},
+	})
+
+	providers := factory.DirectProviders()
+	assert.Empty(t, providers, "Providers requiring API keys should not be enabled without keys")
+}

--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -1264,7 +1264,7 @@ func isBinaryFile(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Read just the first 512 bytes to check for binary content
 	header := make([]byte, 512)


### PR DESCRIPTION
## Summary

- Add provider metadata with `requiresAPIKey` flag to distinguish providers that need API keys from keyless providers
- Enable Ollama to be activated by config presence alone (no API key or explicit `enabled: true` required)
- Centralize default model definitions in `providerMetadata` map

## Problem

The provider factory's `isProviderEnabled` function required either:
1. Explicit `enabled: true` in config, OR
2. A non-empty `APIKey`

This prevented keyless providers like Ollama from being enabled implicitly when config was present.

## Solution

Add `providerMetadata` map that defines per-provider characteristics:

```go
var providerMetadata = map[string]providerMeta{
    "openai":    {requiresAPIKey: true, defaultModel: "gpt-5.2"},
    "anthropic": {requiresAPIKey: true, defaultModel: "claude-sonnet-4-5"},
    "gemini":    {requiresAPIKey: true, defaultModel: "gemini-3-pro-preview"},
    "ollama":    {requiresAPIKey: false, defaultModel: "codellama"},
}
```

Updated `isProviderEnabled` to check this metadata - keyless providers are enabled when present in config.

## Test plan

- [x] `TestNewFactory_OllamaWithExplicitEnabled` - explicit `enabled: true` works
- [x] `TestNewFactory_OllamaWithImplicitEnabled` - config presence enables Ollama
- [x] `TestNewFactory_OllamaExplicitlyDisabled` - explicit `enabled: false` works
- [x] `TestNewFactory_KeyRequiredProvidersStillNeedKeys` - OpenAI/Anthropic still require keys
- [x] All existing tests pass
- [x] Race detection passes

Closes #212