### PR TITLE
feat: expand semantic dedup to support OpenAI and Gemini providers

### DIFF
--- a/cmd/bop/main.go
+++ b/cmd/bop/main.go
@@ -887,7 +887,7 @@ func defaultVerificationModel(provider string) string {
 
 // createSemanticComparer creates a semantic comparer for deduplication.
 // Returns nil if semantic deduplication is disabled or no suitable provider is available.
-// Currently only supports Anthropic as the provider.
+// Supports Anthropic, OpenAI, and Gemini providers.
 func createSemanticComparer(cfg config.Config) usecasedeup.SemanticComparer {
 	semanticCfg := cfg.Deduplication.Semantic
 
@@ -899,46 +899,37 @@ func createSemanticComparer(cfg config.Config) usecasedeup.SemanticComparer {
 	// Start with defaults, override with user config if provided
 	defaults := usecasedeup.DefaultConfig()
 
-	provider := defaults.Provider
-	if semanticCfg.Provider != "" {
-		provider = semanticCfg.Provider
-	}
-
-	model := defaults.Model
-	if semanticCfg.Model != "" {
-		model = semanticCfg.Model
-	}
-
 	maxTokens := defaults.MaxTokens
 	if semanticCfg.MaxTokens > 0 {
 		maxTokens = semanticCfg.MaxTokens
 	}
 
-	// Currently only Anthropic is supported for semantic dedup
-	if provider != "anthropic" {
-		log.Printf("[WARN] Semantic deduplication only supports anthropic provider, got: %s", provider)
+	// Try to create a client for the configured provider (or first available)
+	simpleClient, actualProvider := createSimpleClient(cfg, semanticCfg.Provider, semanticCfg.Model)
+	if simpleClient == nil {
+		// Try fallback providers in order of preference
+		fallbackProviders := []string{"anthropic", "openai", "gemini"}
+		for _, fallback := range fallbackProviders {
+			if fallback == semanticCfg.Provider {
+				continue // Already tried this one
+			}
+			simpleClient, actualProvider = createSimpleClient(cfg, fallback, "")
+			if simpleClient != nil {
+				break
+			}
+		}
+	}
+
+	if simpleClient == nil {
+		log.Println("[INFO] Semantic deduplication disabled: no LLM provider API key available")
 		return nil
 	}
 
-	// Get the Anthropic API key
-	providerCfg, ok := cfg.Providers["anthropic"]
-	if !ok || providerCfg.APIKey == "" {
-		// Try environment variable as fallback
-		apiKey := os.Getenv("ANTHROPIC_API_KEY")
-		if apiKey == "" {
-			log.Println("[WARN] Semantic deduplication disabled: no Anthropic API key available")
-			return nil
-		}
-		providerCfg.APIKey = apiKey
-	}
+	log.Printf("[INFO] Semantic deduplication enabled (provider=%s)", actualProvider)
 
-	// Create the Anthropic client for semantic comparison
-	anthropicClient := dedupadapter.NewAnthropicClient(providerCfg.APIKey, model, providerCfg, cfg.HTTP)
-
-	log.Printf("[INFO] Semantic deduplication enabled (provider=%s, model=%s)", provider, model)
-
-	// Create and return the semantic comparer
-	return dedupadapter.NewComparer(anthropicClient, maxTokens)
+	// Adapt simple.Client to dedup.Client and create the comparer
+	dedupClient := dedupadapter.NewSimpleClientAdapter(simpleClient)
+	return dedupadapter.NewComparer(dedupClient, maxTokens)
 }
 
 // createThemeExtractor creates a theme extractor for reducing thematic repetition.

--- a/internal/adapter/dedup/simple_adapter.go
+++ b/internal/adapter/dedup/simple_adapter.go
@@ -1,0 +1,27 @@
+// Package dedup provides LLM-based semantic deduplication of findings.
+package dedup
+
+import (
+	"context"
+
+	"github.com/delightfulhammers/bop/internal/adapter/llm/simple"
+)
+
+// SimpleClientAdapter adapts a simple.Client to the dedup.Client interface.
+// This allows the simple LLM clients (Anthropic, OpenAI, Gemini) to be used
+// for semantic deduplication, enabling multi-provider support.
+type SimpleClientAdapter struct {
+	client simple.Client
+}
+
+// NewSimpleClientAdapter creates an adapter that wraps a simple.Client
+// to satisfy the dedup.Client interface.
+func NewSimpleClientAdapter(client simple.Client) *SimpleClientAdapter {
+	return &SimpleClientAdapter{client: client}
+}
+
+// Compare implements dedup.Client by delegating to simple.Client.Call.
+// The method signatures are identical, only the names differ.
+func (a *SimpleClientAdapter) Compare(ctx context.Context, prompt string, maxTokens int) (string, error) {
+	return a.client.Call(ctx, prompt, maxTokens)
+}

--- a/internal/adapter/dedup/simple_adapter_test.go
+++ b/internal/adapter/dedup/simple_adapter_test.go
@@ -1,0 +1,71 @@
+package dedup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSimpleClient is a test double for simple.Client.
+type mockSimpleClient struct {
+	response string
+	err      error
+	called   bool
+	prompt   string
+}
+
+func (m *mockSimpleClient) Call(ctx context.Context, prompt string, maxTokens int) (string, error) {
+	m.called = true
+	m.prompt = prompt
+	return m.response, m.err
+}
+
+func TestSimpleClientAdapter_Compare_Success(t *testing.T) {
+	mock := &mockSimpleClient{
+		response: `{"comparisons": [{"pair_index": 0, "is_duplicate": true, "reason": "Same issue"}]}`,
+	}
+
+	adapter := NewSimpleClientAdapter(mock)
+
+	result, err := adapter.Compare(context.Background(), "test prompt", 4096)
+
+	require.NoError(t, err)
+	assert.True(t, mock.called)
+	assert.Equal(t, "test prompt", mock.prompt)
+	assert.Equal(t, mock.response, result)
+}
+
+func TestSimpleClientAdapter_Compare_Error(t *testing.T) {
+	expectedErr := errors.New("API rate limit exceeded")
+	mock := &mockSimpleClient{
+		err: expectedErr,
+	}
+
+	adapter := NewSimpleClientAdapter(mock)
+
+	result, err := adapter.Compare(context.Background(), "test prompt", 4096)
+
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	assert.Empty(t, result)
+	assert.True(t, mock.called)
+}
+
+func TestSimpleClientAdapter_Compare_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	mock := &mockSimpleClient{
+		err: context.Canceled,
+	}
+
+	adapter := NewSimpleClientAdapter(mock)
+
+	_, err := adapter.Compare(ctx, "test prompt", 4096)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
## Summary

Enables semantic deduplication for users with OpenAI or Gemini API keys (previously Anthropic-only).

Closes #241

## Changes

- Add `SimpleClientAdapter` to bridge `simple.Client` → `dedup.Client` interfaces
- Refactor `createSemanticComparer` to use existing `createSimpleClient` helper
- Enable fallback to any available provider (anthropic → openai → gemini)
- Remove Anthropic-only restriction

## How it works

The existing `simple.Client` interface (used by theme extraction) already has implementations for all three providers. This PR adds a thin adapter to make those clients usable for semantic deduplication.

## Test plan

- [x] Unit tests for SimpleClientAdapter
- [x] All existing tests pass
- [x] Lint passes
- [x] Build succeeds