### PR TITLE
feat: add token usage tracking for theme extraction and semantic dedup (#235)

### DIFF
--- a/internal/adapter/dedup/comparer.go
+++ b/internal/adapter/dedup/comparer.go
@@ -19,6 +19,21 @@ type Client interface {
 	Compare(ctx context.Context, prompt string, maxTokens int) (string, error)
 }
 
+// UsageProvider is an optional interface for clients that track token usage.
+// If the client implements this interface, usage can be retrieved for cost accounting.
+type UsageProvider interface {
+	// TotalUsage returns the accumulated token usage.
+	TotalUsage() Usage
+	// ResetUsage clears the accumulated usage.
+	ResetUsage()
+}
+
+// Usage contains token consumption metrics.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
 // Comparer implements semantic comparison using an LLM.
 type Comparer struct {
 	client    Client
@@ -30,6 +45,28 @@ func NewComparer(client Client, maxTokens int) *Comparer {
 	return &Comparer{
 		client:    client,
 		maxTokens: maxTokens,
+	}
+}
+
+// TotalUsage returns the accumulated token usage if the client tracks it.
+// Returns zero usage if the client doesn't implement UsageProvider.
+// This implements dedup.UsageProvider for cost accounting.
+func (c *Comparer) TotalUsage() dedup.Usage {
+	if up, ok := c.client.(UsageProvider); ok {
+		u := up.TotalUsage()
+		return dedup.Usage{
+			InputTokens:  u.InputTokens,
+			OutputTokens: u.OutputTokens,
+		}
+	}
+	return dedup.Usage{}
+}
+
+// ResetUsage clears the accumulated token usage if the client tracks it.
+// This implements dedup.UsageProvider for cost accounting.
+func (c *Comparer) ResetUsage() {
+	if up, ok := c.client.(UsageProvider); ok {
+		up.ResetUsage()
 	}
 }
 

--- a/internal/adapter/dedup/simple_adapter.go
+++ b/internal/adapter/dedup/simple_adapter.go
@@ -3,6 +3,7 @@ package dedup
 
 import (
 	"context"
+	"sync"
 
 	"github.com/delightfulhammers/bop/internal/adapter/llm/simple"
 )
@@ -10,8 +11,14 @@ import (
 // SimpleClientAdapter adapts a simple.Client to the dedup.Client interface.
 // This allows the simple LLM clients (Anthropic, OpenAI, Gemini) to be used
 // for semantic deduplication, enabling multi-provider support.
+//
+// The adapter accumulates token usage across all Compare calls, which can be
+// retrieved via TotalUsage() for cost accounting.
 type SimpleClientAdapter struct {
 	client simple.Client
+
+	mu         sync.Mutex
+	totalUsage simple.Usage
 }
 
 // NewSimpleClientAdapter creates an adapter that wraps a simple.Client
@@ -21,7 +28,39 @@ func NewSimpleClientAdapter(client simple.Client) *SimpleClientAdapter {
 }
 
 // Compare implements dedup.Client by delegating to simple.Client.Call.
-// The method signatures are identical, only the names differ.
+// Token usage is accumulated and can be retrieved via TotalUsage().
 func (a *SimpleClientAdapter) Compare(ctx context.Context, prompt string, maxTokens int) (string, error) {
-	return a.client.Call(ctx, prompt, maxTokens)
+	text, usage, err := a.client.Call(ctx, prompt, maxTokens)
+	if err != nil {
+		return "", err
+	}
+
+	// Accumulate usage for cost accounting
+	a.mu.Lock()
+	a.totalUsage.InputTokens += usage.InputTokens
+	a.totalUsage.OutputTokens += usage.OutputTokens
+	a.mu.Unlock()
+
+	return text, nil
+}
+
+// TotalUsage returns the accumulated token usage across all Compare calls.
+// This is used for cost accounting after deduplication completes.
+// Implements the UsageProvider interface for the Comparer.
+func (a *SimpleClientAdapter) TotalUsage() Usage {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return Usage{
+		InputTokens:  a.totalUsage.InputTokens,
+		OutputTokens: a.totalUsage.OutputTokens,
+	}
+}
+
+// ResetUsage clears the accumulated token usage.
+// Useful when the adapter is reused across multiple reviews.
+// Implements the UsageProvider interface for the Comparer.
+func (a *SimpleClientAdapter) ResetUsage() {
+	a.mu.Lock()
+	a.totalUsage = simple.Usage{}
+	a.mu.Unlock()
 }

--- a/internal/adapter/dedup/simple_adapter_test.go
+++ b/internal/adapter/dedup/simple_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/delightfulhammers/bop/internal/adapter/llm/simple"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,15 +13,16 @@ import (
 // mockSimpleClient is a test double for simple.Client.
 type mockSimpleClient struct {
 	response string
+	usage    simple.Usage
 	err      error
 	called   bool
 	prompt   string
 }
 
-func (m *mockSimpleClient) Call(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (m *mockSimpleClient) Call(ctx context.Context, prompt string, maxTokens int) (string, simple.Usage, error) {
 	m.called = true
 	m.prompt = prompt
-	return m.response, m.err
+	return m.response, m.usage, m.err
 }
 
 func TestSimpleClientAdapter_Compare_Success(t *testing.T) {
@@ -68,4 +70,74 @@ func TestSimpleClientAdapter_Compare_ContextCancellation(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSimpleClientAdapter_TotalUsage_Accumulates(t *testing.T) {
+	mock := &mockSimpleClient{
+		response: "response",
+		usage:    simple.Usage{InputTokens: 100, OutputTokens: 50},
+	}
+
+	adapter := NewSimpleClientAdapter(mock)
+
+	// First call
+	_, err := adapter.Compare(context.Background(), "prompt1", 4096)
+	require.NoError(t, err)
+
+	usage := adapter.TotalUsage()
+	assert.Equal(t, 100, usage.InputTokens)
+	assert.Equal(t, 50, usage.OutputTokens)
+
+	// Second call - usage should accumulate
+	_, err = adapter.Compare(context.Background(), "prompt2", 4096)
+	require.NoError(t, err)
+
+	usage = adapter.TotalUsage()
+	assert.Equal(t, 200, usage.InputTokens)
+	assert.Equal(t, 100, usage.OutputTokens)
+}
+
+func TestSimpleClientAdapter_ResetUsage(t *testing.T) {
+	mock := &mockSimpleClient{
+		response: "response",
+		usage:    simple.Usage{InputTokens: 100, OutputTokens: 50},
+	}
+
+	adapter := NewSimpleClientAdapter(mock)
+
+	// Accumulate some usage
+	_, err := adapter.Compare(context.Background(), "prompt", 4096)
+	require.NoError(t, err)
+	assert.Equal(t, 100, adapter.TotalUsage().InputTokens)
+
+	// Reset should clear usage
+	adapter.ResetUsage()
+	usage := adapter.TotalUsage()
+	assert.Equal(t, 0, usage.InputTokens)
+	assert.Equal(t, 0, usage.OutputTokens)
+}
+
+func TestSimpleClientAdapter_Error_DoesNotAccumulateUsage(t *testing.T) {
+	mock := &mockSimpleClient{
+		err:   errors.New("API error"),
+		usage: simple.Usage{InputTokens: 100, OutputTokens: 50},
+	}
+
+	adapter := NewSimpleClientAdapter(mock)
+
+	_, err := adapter.Compare(context.Background(), "prompt", 4096)
+	require.Error(t, err)
+
+	// Usage should not be accumulated on error
+	usage := adapter.TotalUsage()
+	assert.Equal(t, 0, usage.InputTokens)
+	assert.Equal(t, 0, usage.OutputTokens)
+}
+
+func TestSimpleClientAdapter_ImplementsUsageProvider(t *testing.T) {
+	mock := &mockSimpleClient{}
+	adapter := NewSimpleClientAdapter(mock)
+
+	// Verify the adapter implements UsageProvider
+	var _ UsageProvider = adapter
 }

--- a/internal/adapter/llm/simple/anthropic.go
+++ b/internal/adapter/llm/simple/anthropic.go
@@ -47,27 +47,29 @@ func NewAnthropicClient(apiKey, model string, providerCfg config.ProviderConfig,
 }
 
 // Call implements Client.
-func (c *AnthropicClient) Call(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (c *AnthropicClient) Call(ctx context.Context, prompt string, maxTokens int) (string, Usage, error) {
 	var result string
+	var usage Usage
 
 	operation := func(ctx context.Context) error {
-		resp, err := c.doRequest(ctx, prompt, maxTokens)
+		resp, u, err := c.doRequest(ctx, prompt, maxTokens)
 		if err != nil {
 			return err
 		}
 		result = resp
+		usage = u
 		return nil
 	}
 
 	err := llmhttp.RetryWithBackoff(ctx, operation, c.retryConf)
 	if err != nil {
-		return "", err
+		return "", Usage{}, err
 	}
 
-	return result, nil
+	return result, usage, nil
 }
 
-func (c *AnthropicClient) doRequest(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (c *AnthropicClient) doRequest(ctx context.Context, prompt string, maxTokens int) (string, Usage, error) {
 	reqBody := anthropicRequest{
 		Model:     c.model,
 		MaxTokens: maxTokens,
@@ -78,12 +80,12 @@ func (c *AnthropicClient) doRequest(ctx context.Context, prompt string, maxToken
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicBaseURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -92,28 +94,28 @@ func (c *AnthropicClient) doRequest(ctx context.Context, prompt string, maxToken
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", classifyHTTPError(err)
+		return "", Usage{}, classifyHTTPError(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	limitedReader := io.LimitReader(resp.Body, maxResponseSize)
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	// Check if response was truncated
 	if int64(len(body)) >= maxResponseSize {
-		return "", fmt.Errorf("response exceeded maximum size of %d bytes", maxResponseSize)
+		return "", Usage{}, fmt.Errorf("response exceeded maximum size of %d bytes", maxResponseSize)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", mapAnthropicError(resp.StatusCode, body)
+		return "", Usage{}, mapAnthropicError(resp.StatusCode, body)
 	}
 
 	var apiResp anthropicResponse
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	var sb strings.Builder
@@ -123,7 +125,12 @@ func (c *AnthropicClient) doRequest(ctx context.Context, prompt string, maxToken
 		}
 	}
 
-	return sb.String(), nil
+	usage := Usage{
+		InputTokens:  apiResp.Usage.InputTokens,
+		OutputTokens: apiResp.Usage.OutputTokens,
+	}
+
+	return sb.String(), usage, nil
 }
 
 type anthropicRequest struct {
@@ -139,6 +146,10 @@ type anthropicMessage struct {
 
 type anthropicResponse struct {
 	Content []anthropicContent `json:"content"`
+	Usage   struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
 }
 
 type anthropicContent struct {

--- a/internal/adapter/llm/simple/client.go
+++ b/internal/adapter/llm/simple/client.go
@@ -8,11 +8,17 @@ import (
 	"context"
 )
 
+// Usage contains token consumption metrics from an LLM call.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
 // Client defines a simple interface for LLM text completion.
 // This is used by auxiliary services like theme extraction and semantic dedup
 // that don't need the full structured review response format.
 type Client interface {
-	// Call sends a prompt to the LLM and returns the response text.
+	// Call sends a prompt to the LLM and returns the response text and token usage.
 	// maxTokens limits the response size.
-	Call(ctx context.Context, prompt string, maxTokens int) (string, error)
+	Call(ctx context.Context, prompt string, maxTokens int) (string, Usage, error)
 }

--- a/internal/adapter/llm/simple/gemini.go
+++ b/internal/adapter/llm/simple/gemini.go
@@ -44,27 +44,29 @@ func NewGeminiClient(apiKey, model string, providerCfg config.ProviderConfig, ht
 }
 
 // Call implements Client.
-func (c *GeminiClient) Call(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (c *GeminiClient) Call(ctx context.Context, prompt string, maxTokens int) (string, Usage, error) {
 	var result string
+	var usage Usage
 
 	operation := func(ctx context.Context) error {
-		resp, err := c.doRequest(ctx, prompt, maxTokens)
+		resp, u, err := c.doRequest(ctx, prompt, maxTokens)
 		if err != nil {
 			return err
 		}
 		result = resp
+		usage = u
 		return nil
 	}
 
 	err := llmhttp.RetryWithBackoff(ctx, operation, c.retryConf)
 	if err != nil {
-		return "", err
+		return "", Usage{}, err
 	}
 
-	return result, nil
+	return result, usage, nil
 }
 
-func (c *GeminiClient) doRequest(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (c *GeminiClient) doRequest(ctx context.Context, prompt string, maxTokens int) (string, Usage, error) {
 	reqBody := geminiRequest{
 		Contents: []geminiContent{
 			{
@@ -85,13 +87,13 @@ func (c *GeminiClient) doRequest(ctx context.Context, prompt string, maxTokens i
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	apiURL := fmt.Sprintf("%s/v1beta/models/%s:generateContent", geminiBaseURL, c.model)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -99,32 +101,32 @@ func (c *GeminiClient) doRequest(ctx context.Context, prompt string, maxTokens i
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", classifyHTTPError(err)
+		return "", Usage{}, classifyHTTPError(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	limitedReader := io.LimitReader(resp.Body, geminiMaxResponse)
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	// Check if response was truncated
 	if int64(len(body)) >= geminiMaxResponse {
-		return "", fmt.Errorf("response exceeded maximum size of %d bytes", geminiMaxResponse)
+		return "", Usage{}, fmt.Errorf("response exceeded maximum size of %d bytes", geminiMaxResponse)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", mapGeminiError(resp.StatusCode, body)
+		return "", Usage{}, mapGeminiError(resp.StatusCode, body)
 	}
 
 	var apiResp geminiResponse
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	if len(apiResp.Candidates) == 0 || len(apiResp.Candidates[0].Content.Parts) == 0 {
-		return "", fmt.Errorf("no content in response")
+		return "", Usage{}, fmt.Errorf("no content in response")
 	}
 
 	// Concatenate all parts (Gemini can return multiple parts for complex responses)
@@ -133,7 +135,12 @@ func (c *GeminiClient) doRequest(ctx context.Context, prompt string, maxTokens i
 		sb.WriteString(part.Text)
 	}
 
-	return sb.String(), nil
+	usage := Usage{
+		InputTokens:  apiResp.UsageMetadata.PromptTokenCount,
+		OutputTokens: apiResp.UsageMetadata.CandidatesTokenCount,
+	}
+
+	return sb.String(), usage, nil
 }
 
 type geminiRequest struct {
@@ -161,7 +168,11 @@ type geminiSafetySetting struct {
 }
 
 type geminiResponse struct {
-	Candidates []geminiCandidate `json:"candidates"`
+	Candidates    []geminiCandidate `json:"candidates"`
+	UsageMetadata struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+	} `json:"usageMetadata"`
 }
 
 type geminiCandidate struct {

--- a/internal/adapter/llm/simple/openai.go
+++ b/internal/adapter/llm/simple/openai.go
@@ -44,24 +44,26 @@ func NewOpenAIClient(apiKey, model string, providerCfg config.ProviderConfig, ht
 }
 
 // Call implements Client.
-func (c *OpenAIClient) Call(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (c *OpenAIClient) Call(ctx context.Context, prompt string, maxTokens int) (string, Usage, error) {
 	var result string
+	var usage Usage
 
 	operation := func(ctx context.Context) error {
-		resp, err := c.doRequest(ctx, prompt, maxTokens)
+		resp, u, err := c.doRequest(ctx, prompt, maxTokens)
 		if err != nil {
 			return err
 		}
 		result = resp
+		usage = u
 		return nil
 	}
 
 	err := llmhttp.RetryWithBackoff(ctx, operation, c.retryConf)
 	if err != nil {
-		return "", err
+		return "", Usage{}, err
 	}
 
-	return result, nil
+	return result, usage, nil
 }
 
 // isReasoningModel checks if the model is an OpenAI reasoning model.
@@ -91,7 +93,7 @@ func usesMaxCompletionTokens(model string) bool {
 	return false
 }
 
-func (c *OpenAIClient) doRequest(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (c *OpenAIClient) doRequest(ctx context.Context, prompt string, maxTokens int) (string, Usage, error) {
 	reqBody := openaiRequest{
 		Model: c.model,
 		Messages: []openaiMessage{
@@ -108,12 +110,12 @@ func (c *OpenAIClient) doRequest(ctx context.Context, prompt string, maxTokens i
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openaiBaseURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -121,40 +123,45 @@ func (c *OpenAIClient) doRequest(ctx context.Context, prompt string, maxTokens i
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", classifyHTTPError(err)
+		return "", Usage{}, classifyHTTPError(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	limitedReader := io.LimitReader(resp.Body, openaiMaxResponse)
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	// Check if response was truncated
 	if int64(len(body)) >= openaiMaxResponse {
-		return "", fmt.Errorf("response exceeded maximum size of %d bytes", openaiMaxResponse)
+		return "", Usage{}, fmt.Errorf("response exceeded maximum size of %d bytes", openaiMaxResponse)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", mapOpenAIError(resp.StatusCode, body)
+		return "", Usage{}, mapOpenAIError(resp.StatusCode, body)
 	}
 
 	var apiResp openaiResponse
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
+		return "", Usage{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	if len(apiResp.Choices) == 0 {
-		return "", fmt.Errorf("no choices in response")
+		return "", Usage{}, fmt.Errorf("no choices in response")
 	}
 
 	content := apiResp.Choices[0].Message.Content
 	if content == "" {
-		return "", fmt.Errorf("empty content in response")
+		return "", Usage{}, fmt.Errorf("empty content in response")
 	}
 
-	return content, nil
+	usage := Usage{
+		InputTokens:  apiResp.Usage.PromptTokens,
+		OutputTokens: apiResp.Usage.CompletionTokens,
+	}
+
+	return content, usage, nil
 }
 
 type openaiRequest struct {
@@ -171,6 +178,10 @@ type openaiMessage struct {
 
 type openaiResponse struct {
 	Choices []openaiChoice `json:"choices"`
+	Usage   struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
 }
 
 type openaiChoice struct {

--- a/internal/adapter/theme/extractor.go
+++ b/internal/adapter/theme/extractor.go
@@ -53,7 +53,7 @@ func (e *Extractor) ExtractThemes(ctx context.Context, findings []domain.Triaged
 	prompt := e.buildExtractionPrompt(findings)
 
 	// Call the LLM
-	response, err := e.client.Call(ctx, prompt, e.config.MaxTokens)
+	response, usage, err := e.client.Call(ctx, prompt, e.config.MaxTokens)
 	if err != nil {
 		log.Printf("warning: theme extraction LLM call failed: %v", err)
 		return result, err
@@ -68,6 +68,10 @@ func (e *Extractor) ExtractThemes(ctx context.Context, findings []domain.Triaged
 
 	// Preserve FindingCount from the input (parsing doesn't know about it)
 	parsed.FindingCount = len(findings)
+
+	// Capture token usage for cost accounting
+	parsed.TokensIn = usage.InputTokens
+	parsed.TokensOut = usage.OutputTokens
 
 	return parsed, nil
 }

--- a/internal/adapter/theme/extractor_test.go
+++ b/internal/adapter/theme/extractor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/delightfulhammers/bop/internal/adapter/llm/simple"
 	"github.com/delightfulhammers/bop/internal/domain"
 	"github.com/delightfulhammers/bop/internal/usecase/review"
 	"github.com/stretchr/testify/assert"
@@ -14,15 +15,16 @@ import (
 // mockClient is a test double for the simple.Client interface.
 type mockClient struct {
 	response string
+	usage    simple.Usage
 	err      error
 	called   bool
 	prompt   string
 }
 
-func (m *mockClient) Call(ctx context.Context, prompt string, maxTokens int) (string, error) {
+func (m *mockClient) Call(ctx context.Context, prompt string, maxTokens int) (string, simple.Usage, error) {
 	m.called = true
 	m.prompt = prompt
-	return m.response, m.err
+	return m.response, m.usage, m.err
 }
 
 func TestExtractor_ExtractThemes_Success(t *testing.T) {
@@ -699,4 +701,59 @@ func TestExtractor_IsEmpty(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.result.IsEmpty())
 		})
 	}
+}
+
+func TestExtractor_ExtractThemes_CapturesUsage(t *testing.T) {
+	client := &mockClient{
+		response: `{"themes": ["validation"]}`,
+		usage:    simple.Usage{InputTokens: 500, OutputTokens: 100},
+	}
+
+	config := review.ThemeExtractionConfig{
+		Strategy:            review.StrategyAbstract,
+		MaxThemes:           10,
+		MinFindingsForTheme: 3,
+		MaxTokens:           4096,
+	}
+
+	extractor := NewExtractor(client, config)
+
+	findings := []domain.TriagedFinding{
+		{File: "a.go", Description: "Issue 1"},
+		{File: "b.go", Description: "Issue 2"},
+		{File: "c.go", Description: "Issue 3"},
+	}
+
+	result, err := extractor.ExtractThemes(context.Background(), findings)
+
+	require.NoError(t, err)
+	assert.Equal(t, 500, result.TokensIn)
+	assert.Equal(t, 100, result.TokensOut)
+}
+
+func TestExtractor_ExtractThemes_TooFewFindings_NoUsage(t *testing.T) {
+	client := &mockClient{
+		usage: simple.Usage{InputTokens: 500, OutputTokens: 100},
+	}
+
+	config := review.ThemeExtractionConfig{
+		MaxThemes:           10,
+		MinFindingsForTheme: 5, // Require 5, only provide 2
+		MaxTokens:           4096,
+	}
+
+	extractor := NewExtractor(client, config)
+
+	findings := []domain.TriagedFinding{
+		{File: "a.go", Description: "Issue 1"},
+		{File: "b.go", Description: "Issue 2"},
+	}
+
+	result, err := extractor.ExtractThemes(context.Background(), findings)
+
+	require.NoError(t, err)
+	assert.False(t, client.called, "LLM should not be called when too few findings")
+	// No LLM call means no usage
+	assert.Equal(t, 0, result.TokensIn)
+	assert.Equal(t, 0, result.TokensOut)
 }

--- a/internal/usecase/dedup/dedup.go
+++ b/internal/usecase/dedup/dedup.go
@@ -76,6 +76,22 @@ type SemanticComparer interface {
 	Compare(ctx context.Context, candidates []CandidatePair) (*ComparisonResult, error)
 }
 
+// Usage contains token consumption metrics from semantic comparison.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// UsageProvider is an optional interface for comparers that track token usage.
+// Callers can check if a SemanticComparer implements this interface to retrieve
+// accumulated usage for cost accounting.
+type UsageProvider interface {
+	// TotalUsage returns the accumulated token usage.
+	TotalUsage() Usage
+	// ResetUsage clears the accumulated usage.
+	ResetUsage()
+}
+
 // Config holds configuration for semantic deduplication.
 type Config struct {
 	// Provider is the LLM provider name (e.g., "anthropic").

--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -856,6 +856,15 @@ func (p *ReviewPoster) filterSemanticDuplicates(
 		return findings, 0, nil
 	}
 
+	// Log token usage for cost accounting if the comparer tracks it
+	if up, ok := p.semanticComparer.(dedup.UsageProvider); ok {
+		usage := up.TotalUsage()
+		if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+			log.Printf("semantic dedup: tokens=%d/%d, candidates=%d, duplicates=%d",
+				usage.InputTokens, usage.OutputTokens, len(candidates), len(result.Duplicates))
+		}
+	}
+
 	// Mark original finding indices that are semantic duplicates.
 	// Only consider indices that were actually sent as candidates (not overflow).
 	// Also build a map of new fingerprints -> existing fingerprints for status inheritance.

--- a/internal/usecase/review/orchestrator.go
+++ b/internal/usecase/review/orchestrator.go
@@ -584,10 +584,13 @@ func (o *Orchestrator) ReviewBranch(ctx context.Context, req BranchRequest) (Res
 							"conclusions_count": len(result.Conclusions),
 							"disputed_count":    len(result.DisputedPatterns),
 							"finding_count":     result.FindingCount,
+							"tokens_in":         result.TokensIn,
+							"tokens_out":        result.TokensOut,
 						})
 					} else {
-						log.Printf("Extracted %d themes, %d conclusions, %d disputed patterns (strategy: %s)\n",
-							len(result.Themes), len(result.Conclusions), len(result.DisputedPatterns), result.Strategy)
+						log.Printf("Extracted %d themes, %d conclusions, %d disputed patterns (strategy: %s, tokens: %d/%d)\n",
+							len(result.Themes), len(result.Conclusions), len(result.DisputedPatterns), result.Strategy,
+							result.TokensIn, result.TokensOut)
 					}
 				} else {
 					// Log when extraction succeeds but returns empty (helps debug missing themes)
@@ -1101,10 +1104,13 @@ func (o *Orchestrator) ReviewBranchWithDiff(ctx context.Context, req BranchReque
 							"conclusions_count": len(result.Conclusions),
 							"disputed_count":    len(result.DisputedPatterns),
 							"finding_count":     result.FindingCount,
+							"tokens_in":         result.TokensIn,
+							"tokens_out":        result.TokensOut,
 						})
 					} else {
-						log.Printf("Extracted %d themes, %d conclusions, %d disputed patterns (strategy: %s)\n",
-							len(result.Themes), len(result.Conclusions), len(result.DisputedPatterns), result.Strategy)
+						log.Printf("Extracted %d themes, %d conclusions, %d disputed patterns (strategy: %s, tokens: %d/%d)\n",
+							len(result.Themes), len(result.Conclusions), len(result.DisputedPatterns), result.Strategy,
+							result.TokensIn, result.TokensOut)
 					}
 				} else {
 					// Log when extraction succeeds but returns empty (helps debug missing themes)

--- a/internal/usecase/review/theme_extractor.go
+++ b/internal/usecase/review/theme_extractor.go
@@ -69,6 +69,14 @@ type ThemeExtractionResult struct {
 
 	// FindingCount is the number of findings that were analyzed.
 	FindingCount int
+
+	// TokensIn is the number of input tokens used for extraction.
+	// Used for cost accounting.
+	TokensIn int
+
+	// TokensOut is the number of output tokens used for extraction.
+	// Used for cost accounting.
+	TokensOut int
 }
 
 // ThemeConclusion represents a specific decision made during review.


### PR DESCRIPTION
## Summary

- Add cost accounting for auxiliary LLM calls (theme extraction and semantic dedup) that were previously invisible
- Extend `simple.Client` interface to return `Usage` with token counts from all three providers
- Log token usage in orchestrator and poster for cost visibility

## Test plan

- [x] All existing tests pass
- [x] New tests for usage accumulation in `SimpleClientAdapter`
- [x] New tests for usage propagation in theme extractor
- [x] Linting passes
- [x] Build succeeds

Closes #235