### PR TITLE
feat: surface out-of-diff findings to MCP tools via issue comments

### DIFF
--- a/bop.yaml
+++ b/bop.yaml
@@ -332,6 +332,16 @@ review:
   alwaysBlockCategories:
     # - "security"
 
+  # Post out-of-diff findings as individual issue comments (default: true)
+  # Out-of-diff findings are on lines not included in the PR diff (deleted lines,
+  # unchanged context) and cannot be posted as inline review comments.
+  # When enabled (default), these findings are posted as issue comments with
+  # fingerprint markers, making them visible to MCP tools for triage.
+  # The summary comment still includes an "Findings Outside Diff" section for
+  # human readability, but the individual comments enable machine interaction.
+  # Set to false to only include out-of-diff findings in the summary comment.
+  postOutOfDiffAsComments: true
+
   # Fine-grained action control (overrides blockThreshold for specific severities)
   # actions:
   #   onCritical: "request_changes"

--- a/internal/adapter/github/issue_comments.go
+++ b/internal/adapter/github/issue_comments.go
@@ -1,0 +1,317 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	llmhttp "github.com/delightfulhammers/bop/internal/adapter/llm/http"
+	"github.com/delightfulhammers/bop/internal/usecase/triage"
+)
+
+// outOfDiffPattern matches CR_OOD:true markers in comment bodies.
+var outOfDiffPattern = regexp.MustCompile(`CR_OOD:true`)
+
+// IssueComment represents a GitHub issue comment (PR conversation comment).
+// Unlike review comments, issue comments don't have file paths or line numbers.
+type IssueComment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	User      User   `json:"user"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	HTMLURL   string `json:"html_url"`
+}
+
+// HasFingerprint returns true if this comment contains a CR_FP marker.
+func (c IssueComment) HasFingerprint() bool {
+	return fingerprintPattern.MatchString(c.Body)
+}
+
+// IsOutOfDiffFinding returns true if this comment is an out-of-diff finding
+// (contains both CR_FP and CR_OOD:true markers).
+func (c IssueComment) IsOutOfDiffFinding() bool {
+	return c.HasFingerprint() && outOfDiffPattern.MatchString(c.Body)
+}
+
+// CreateIssueComment posts an issue comment on a PR (in the conversation thread).
+// GitHub API: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+// Note: PRs are treated as issues in the GitHub API, so we use the issues endpoint.
+// Returns the ID of the created comment.
+func (c *Client) CreateIssueComment(ctx context.Context, owner, repo string, prNumber int, body string) (int64, error) {
+	// Validate inputs
+	if err := validatePathSegment(owner, "owner"); err != nil {
+		return 0, err
+	}
+	if err := validatePathSegment(repo, "repo"); err != nil {
+		return 0, err
+	}
+	if prNumber <= 0 {
+		return 0, fmt.Errorf("invalid PR number: %d (must be positive)", prNumber)
+	}
+	if strings.TrimSpace(body) == "" {
+		return 0, fmt.Errorf("empty body: comment body is required")
+	}
+
+	// Build request body
+	reqBody := struct {
+		Body string `json:"body"`
+	}{Body: body}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return 0, fmt.Errorf("marshal request: %w", err)
+	}
+
+	// GitHub API: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments",
+		c.baseURL, url.PathEscape(owner), url.PathEscape(repo), prNumber)
+
+	var resp *http.Response
+	err = llmhttp.RetryWithBackoff(ctx, func(ctx context.Context) error {
+		req, reqErr := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(jsonData))
+		if reqErr != nil {
+			return &llmhttp.Error{
+				Type:      llmhttp.ErrTypeUnknown,
+				Message:   reqErr.Error(),
+				Retryable: false,
+				Provider:  providerName,
+			}
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		var callErr error
+		resp, callErr = c.httpClient.Do(req)
+		if callErr != nil {
+			return llmhttp.ClassifyNetworkError(providerName, callErr, ctx)
+		}
+
+		if resp.StatusCode >= 400 {
+			bodyBytes, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return &llmhttp.Error{
+					Type:       llmhttp.ErrTypeUnknown,
+					Message:    fmt.Sprintf("HTTP %d (failed to read response: %v)", resp.StatusCode, readErr),
+					StatusCode: resp.StatusCode,
+					Retryable:  resp.StatusCode >= 500,
+					Provider:   providerName,
+				}
+			}
+			return MapHTTPError(resp.StatusCode, bodyBytes)
+		}
+
+		return nil
+	}, c.retryConf)
+
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result IssueComment
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode response: %w", err)
+	}
+
+	return result.ID, nil
+}
+
+// ListIssueComments retrieves all issue comments on a PR.
+// GitHub API: GET /repos/{owner}/{repo}/issues/{issue_number}/comments
+// Note: PRs are treated as issues in the GitHub API, so we use the issues endpoint.
+// Returns comments in chronological order (oldest first).
+func (c *Client) ListIssueComments(ctx context.Context, owner, repo string, prNumber int) ([]IssueComment, error) {
+	// Validate inputs
+	if err := validatePathSegment(owner, "owner"); err != nil {
+		return nil, err
+	}
+	if err := validatePathSegment(repo, "repo"); err != nil {
+		return nil, err
+	}
+	if prNumber <= 0 {
+		return nil, fmt.Errorf("invalid PR number: %d (must be positive)", prNumber)
+	}
+
+	var allComments []IssueComment
+	visitedURLs := make(map[string]bool)
+	pageCount := 0
+
+	// Start with the first page
+	nextURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100",
+		c.baseURL, url.PathEscape(owner), url.PathEscape(repo), prNumber)
+
+	for nextURL != "" {
+		// Pagination loop protection
+		if pageCount >= maxPaginationPages {
+			return nil, fmt.Errorf("pagination limit exceeded (%d pages)", maxPaginationPages)
+		}
+		if visitedURLs[nextURL] {
+			return nil, fmt.Errorf("pagination loop detected: URL already visited")
+		}
+		visitedURLs[nextURL] = true
+		pageCount++
+
+		pageComments, next, err := c.fetchIssueCommentsPage(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+		allComments = append(allComments, pageComments...)
+
+		// Validate and resolve pagination URL
+		if next != "" {
+			resolved, err := c.ValidateAndResolvePaginationURL(next)
+			if err != nil {
+				return nil, fmt.Errorf("unsafe pagination URL in Link header: %w", err)
+			}
+			next = resolved
+		}
+		nextURL = next
+	}
+
+	return allComments, nil
+}
+
+// fetchIssueCommentsPage fetches a single page of issue comments.
+func (c *Client) fetchIssueCommentsPage(ctx context.Context, pageURL string) ([]IssueComment, string, error) {
+	var resp *http.Response
+	err := llmhttp.RetryWithBackoff(ctx, func(ctx context.Context) error {
+		req, reqErr := http.NewRequestWithContext(ctx, "GET", pageURL, nil)
+		if reqErr != nil {
+			return &llmhttp.Error{
+				Type:      llmhttp.ErrTypeUnknown,
+				Message:   reqErr.Error(),
+				Retryable: false,
+				Provider:  providerName,
+			}
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		var callErr error
+		resp, callErr = c.httpClient.Do(req)
+		if callErr != nil {
+			return llmhttp.ClassifyNetworkError(providerName, callErr, ctx)
+		}
+
+		if resp.StatusCode >= 400 {
+			bodyBytes, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return &llmhttp.Error{
+					Type:       llmhttp.ErrTypeUnknown,
+					Message:    fmt.Sprintf("HTTP %d (failed to read response: %v)", resp.StatusCode, readErr),
+					StatusCode: resp.StatusCode,
+					Retryable:  resp.StatusCode >= 500,
+					Provider:   providerName,
+				}
+			}
+			return MapHTTPError(resp.StatusCode, bodyBytes)
+		}
+
+		return nil
+	}, c.retryConf)
+
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var comments []IssueComment
+	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+		return nil, "", fmt.Errorf("decode response: %w", err)
+	}
+
+	// Parse Link header for pagination
+	nextURL := parseNextLink(resp.Header.Get("Link"))
+
+	return comments, nextURL, nil
+}
+
+// GetIssueComment retrieves a single issue comment by ID.
+// GitHub API: GET /repos/{owner}/{repo}/issues/comments/{comment_id}
+// Returns ErrCommentNotFound if the comment doesn't exist.
+func (c *Client) GetIssueComment(ctx context.Context, owner, repo string, commentID int64) (*IssueComment, error) {
+	// Validate inputs
+	if err := validatePathSegment(owner, "owner"); err != nil {
+		return nil, err
+	}
+	if err := validatePathSegment(repo, "repo"); err != nil {
+		return nil, err
+	}
+	if commentID <= 0 {
+		return nil, fmt.Errorf("invalid comment ID: %d (must be positive)", commentID)
+	}
+
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d",
+		c.baseURL, url.PathEscape(owner), url.PathEscape(repo), commentID)
+
+	var resp *http.Response
+	err := llmhttp.RetryWithBackoff(ctx, func(ctx context.Context) error {
+		req, reqErr := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+		if reqErr != nil {
+			return &llmhttp.Error{
+				Type:      llmhttp.ErrTypeUnknown,
+				Message:   reqErr.Error(),
+				Retryable: false,
+				Provider:  providerName,
+			}
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		var callErr error
+		resp, callErr = c.httpClient.Do(req)
+		if callErr != nil {
+			return llmhttp.ClassifyNetworkError(providerName, callErr, ctx)
+		}
+
+		if resp.StatusCode == 404 {
+			_ = resp.Body.Close()
+			return triage.ErrCommentNotFound
+		}
+
+		if resp.StatusCode >= 400 {
+			bodyBytes, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return &llmhttp.Error{
+					Type:       llmhttp.ErrTypeUnknown,
+					Message:    fmt.Sprintf("HTTP %d (failed to read response: %v)", resp.StatusCode, readErr),
+					StatusCode: resp.StatusCode,
+					Retryable:  resp.StatusCode >= 500,
+					Provider:   providerName,
+				}
+			}
+			return MapHTTPError(resp.StatusCode, bodyBytes)
+		}
+
+		return nil
+	}, c.retryConf)
+
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var comment IssueComment
+	if err := json.NewDecoder(resp.Body).Decode(&comment); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return &comment, nil
+}

--- a/internal/adapter/github/issue_comments_test.go
+++ b/internal/adapter/github/issue_comments_test.go
@@ -1,0 +1,343 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_CreateIssueComment(t *testing.T) {
+	tests := []struct {
+		name           string
+		owner          string
+		repo           string
+		prNumber       int
+		body           string
+		responseStatus int
+		responseBody   string
+		wantID         int64
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "successful creation",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       42,
+			body:           "Test comment with <!-- CR_FP:abc123 CR_OOD:true -->",
+			responseStatus: http.StatusCreated,
+			responseBody:   `{"id": 12345, "body": "Test comment", "user": {"login": "github-actions[bot]"}}`,
+			wantID:         12345,
+			wantErr:        false,
+		},
+		{
+			name:           "invalid owner",
+			owner:          "test/owner",
+			repo:           "testrepo",
+			prNumber:       42,
+			body:           "Test",
+			responseStatus: 0, // Won't be called
+			wantErr:        true,
+			errContains:    "invalid owner",
+		},
+		{
+			name:           "invalid repo",
+			owner:          "testowner",
+			repo:           "test..repo",
+			prNumber:       42,
+			body:           "Test",
+			responseStatus: 0, // Won't be called
+			wantErr:        true,
+			errContains:    "invalid repo",
+		},
+		{
+			name:           "invalid PR number",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       0,
+			body:           "Test",
+			responseStatus: 0, // Won't be called
+			wantErr:        true,
+			errContains:    "invalid PR number",
+		},
+		{
+			name:           "empty body",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       42,
+			body:           "",
+			responseStatus: 0, // Won't be called
+			wantErr:        true,
+			errContains:    "empty body",
+		},
+		{
+			name:           "server error",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       42,
+			body:           "Test comment",
+			responseStatus: http.StatusInternalServerError,
+			responseBody:   `{"message": "Internal server error"}`,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request method and path
+				assert.Equal(t, "POST", r.Method)
+				expectedPath := "/repos/" + tt.owner + "/" + tt.repo + "/issues/" + "42" + "/comments"
+				assert.Equal(t, expectedPath, r.URL.Path)
+
+				// Verify request body
+				var reqBody map[string]string
+				err := json.NewDecoder(r.Body).Decode(&reqBody)
+				require.NoError(t, err)
+				assert.Equal(t, tt.body, reqBody["body"])
+
+				w.WriteHeader(tt.responseStatus)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			client := NewClient("test-token")
+			client.SetBaseURL(server.URL)
+			client.SetMaxRetries(0) // Disable retries for tests
+
+			id, err := client.CreateIssueComment(context.Background(), tt.owner, tt.repo, tt.prNumber, tt.body)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantID, id)
+			}
+		})
+	}
+}
+
+func TestClient_ListIssueComments(t *testing.T) {
+	tests := []struct {
+		name           string
+		owner          string
+		repo           string
+		prNumber       int
+		responseStatus int
+		responseBody   string
+		wantCount      int
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "successful list with multiple comments",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       42,
+			responseStatus: http.StatusOK,
+			responseBody: `[
+				{"id": 1, "body": "Regular comment", "user": {"login": "user1", "type": "User"}, "created_at": "2024-01-01T10:00:00Z"},
+				{"id": 2, "body": "<!-- CR_FP:abc123 CR_OOD:true --> Finding", "user": {"login": "github-actions[bot]", "type": "Bot"}, "created_at": "2024-01-01T11:00:00Z"},
+				{"id": 3, "body": "Another comment", "user": {"login": "user2", "type": "User"}, "created_at": "2024-01-01T12:00:00Z"}
+			]`,
+			wantCount: 3,
+			wantErr:   false,
+		},
+		{
+			name:           "empty list",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       42,
+			responseStatus: http.StatusOK,
+			responseBody:   `[]`,
+			wantCount:      0,
+			wantErr:        false,
+		},
+		{
+			name:           "invalid owner",
+			owner:          "../evil",
+			repo:           "testrepo",
+			prNumber:       42,
+			responseStatus: 0, // Won't be called
+			wantErr:        true,
+			errContains:    "invalid owner",
+		},
+		{
+			name:           "server error",
+			owner:          "testowner",
+			repo:           "testrepo",
+			prNumber:       42,
+			responseStatus: http.StatusInternalServerError,
+			responseBody:   `{"message": "Internal server error"}`,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request method
+				assert.Equal(t, "GET", r.Method)
+
+				w.WriteHeader(tt.responseStatus)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			client := NewClient("test-token")
+			client.SetBaseURL(server.URL)
+			client.SetMaxRetries(0)
+
+			comments, err := client.ListIssueComments(context.Background(), tt.owner, tt.repo, tt.prNumber)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, comments, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestClient_GetIssueComment(t *testing.T) {
+	tests := []struct {
+		name           string
+		owner          string
+		repo           string
+		commentID      int64
+		responseStatus int
+		responseBody   string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "successful get",
+			owner:          "testowner",
+			repo:           "testrepo",
+			commentID:      12345,
+			responseStatus: http.StatusOK,
+			responseBody:   `{"id": 12345, "body": "Test comment", "user": {"login": "user1", "type": "User"}, "created_at": "2024-01-01T10:00:00Z"}`,
+			wantErr:        false,
+		},
+		{
+			name:           "not found",
+			owner:          "testowner",
+			repo:           "testrepo",
+			commentID:      99999,
+			responseStatus: http.StatusNotFound,
+			responseBody:   `{"message": "Not Found"}`,
+			wantErr:        true,
+			errContains:    "not found",
+		},
+		{
+			name:           "invalid comment ID",
+			owner:          "testowner",
+			repo:           "testrepo",
+			commentID:      0,
+			responseStatus: 0, // Won't be called
+			wantErr:        true,
+			errContains:    "invalid comment ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "GET", r.Method)
+				w.WriteHeader(tt.responseStatus)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			client := NewClient("test-token")
+			client.SetBaseURL(server.URL)
+			client.SetMaxRetries(0)
+
+			comment, err := client.GetIssueComment(context.Background(), tt.owner, tt.repo, tt.commentID)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.commentID, comment.ID)
+			}
+		})
+	}
+}
+
+func TestIssueComment_HasFingerprint(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment IssueComment
+		want    bool
+	}{
+		{
+			name:    "has fingerprint",
+			comment: IssueComment{Body: "<!-- CR_FP:abc123 CR_OOD:true --> Description"},
+			want:    true,
+		},
+		{
+			name:    "no fingerprint",
+			comment: IssueComment{Body: "Just a regular comment"},
+			want:    false,
+		},
+		{
+			name:    "empty body",
+			comment: IssueComment{Body: ""},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.comment.HasFingerprint()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIssueComment_IsOutOfDiffFinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment IssueComment
+		want    bool
+	}{
+		{
+			name:    "has OOD marker",
+			comment: IssueComment{Body: "<!-- CR_FP:abc123 CR_OOD:true --> Description"},
+			want:    true,
+		},
+		{
+			name:    "fingerprint only, no OOD",
+			comment: IssueComment{Body: "<!-- CR_FP:abc123 --> Description"},
+			want:    false,
+		},
+		{
+			name:    "no markers",
+			comment: IssueComment{Body: "Just a regular comment"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.comment.IsOutOfDiffFinding()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/adapter/github/pr_comments.go
+++ b/internal/adapter/github/pr_comments.go
@@ -515,3 +515,119 @@ func (c *Client) getReplyMetadata(ctx context.Context, owner, repo string, prNum
 	metadataMap := buildReplyMetadataMap(comments)
 	return metadataMap[parentID], nil
 }
+
+// ListAllFindings retrieves both review comments AND issue comments that contain
+// CR_FP markers. This unified view includes in-diff findings (review comments)
+// and out-of-diff findings (issue comments with CR_OOD markers).
+//
+// The returned findings have the IsOutOfDiff field set appropriately:
+// - Review comments: IsOutOfDiff = false
+// - Issue comments with CR_OOD:true: IsOutOfDiff = true
+//
+// Reply tracking for out-of-diff findings uses CR_REPLY_TO markers since GitHub
+// issue comments don't have native threading.
+func (c *Client) ListAllFindings(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error) {
+	// 1. Fetch review comments (in-diff findings)
+	reviewFindings, err := c.ListPRComments(ctx, owner, repo, prNumber, filterByFingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("list review comments: %w", err)
+	}
+
+	// 2. Fetch issue comments
+	issueComments, err := c.ListIssueComments(ctx, owner, repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("list issue comments: %w", err)
+	}
+
+	// 3. Build reply metadata for issue comments (CR_REPLY_TO markers)
+	issueReplyMap := buildIssueCommentReplyMap(issueComments)
+
+	// 4. Convert issue comments with CR_FP markers to findings
+	for _, ic := range issueComments {
+		// Parse fingerprint
+		fingerprint := parseFingerprint(ic.Body)
+
+		// Apply fingerprint filter
+		isTrustedBot := ic.User.Type == "Bot" && trustedBots[strings.ToLower(ic.User.Login)]
+		if filterByFingerprint && fingerprint == "" && !isTrustedBot {
+			continue
+		}
+
+		// Skip replies (they have CR_REPLY_TO markers)
+		if _, isReply := ExtractReplyToMarker(ic.Body); isReply {
+			continue
+		}
+
+		// Convert to domain finding
+		finding := issueCommentToFinding(ic, fingerprint, issueReplyMap[fingerprint])
+		reviewFindings = append(reviewFindings, finding)
+	}
+
+	return reviewFindings, nil
+}
+
+// buildIssueCommentReplyMap builds a map from fingerprint to reply metadata.
+// Issue comments use CR_REPLY_TO markers to link replies to parent findings.
+func buildIssueCommentReplyMap(comments []IssueComment) map[string]replyMetadata {
+	metadata := make(map[string]replyMetadata)
+
+	for _, c := range comments {
+		parentFP, isReply := ExtractReplyToMarker(c.Body)
+		if !isReply || parentFP == "" {
+			continue
+		}
+
+		createdAt, err := time.Parse(time.RFC3339, c.CreatedAt)
+		existing := metadata[parentFP]
+		existing.count++
+
+		// Track the most recent reply
+		if err == nil && createdAt.After(existing.lastReplyAt) {
+			existing.lastReplyAt = createdAt
+			existing.lastReplyBy = c.User.Login
+		}
+		metadata[parentFP] = existing
+	}
+
+	return metadata
+}
+
+// issueCommentToFinding converts an IssueComment to a domain.PRFinding.
+// This is used for out-of-diff findings posted as issue comments.
+func issueCommentToFinding(comment IssueComment, fingerprint string, meta replyMetadata) domain.PRFinding {
+	createdAt, _ := time.Parse(time.RFC3339, comment.CreatedAt)
+
+	// Extract file and line from CR_FILE/CR_LINE markers
+	file, line, _ := ExtractFileLineFromComment(comment.Body)
+
+	// Extract reviewer name
+	reviewer, _ := ExtractReviewerFromComment(comment.Body)
+
+	// Determine if this is an out-of-diff finding
+	isOutOfDiff := ExtractOutOfDiffMarker(comment.Body)
+
+	finding := domain.PRFinding{
+		CommentID:   comment.ID,
+		Fingerprint: fingerprint,
+		Path:        file,
+		Line:        line,
+		Body:        comment.Body,
+		Author:      comment.User.Login,
+		CreatedAt:   createdAt,
+		IsResolved:  false, // Issue comments don't have resolution status
+		ReplyCount:  meta.count,
+		HasReply:    meta.count > 0,
+		Severity:    parseSeverity(comment.Body),
+		Category:    parseCategory(comment.Body),
+		Reviewer:    reviewer,
+		IsOutOfDiff: isOutOfDiff,
+	}
+
+	// Set last reply info if there are replies
+	if meta.count > 0 {
+		finding.LastReplyAt = &meta.lastReplyAt
+		finding.LastReplyBy = meta.lastReplyBy
+	}
+
+	return finding
+}

--- a/internal/adapter/github/pr_comments_test.go
+++ b/internal/adapter/github/pr_comments_test.go
@@ -659,3 +659,190 @@ func TestResolveFindingID(t *testing.T) {
 func intPtr(i int) *int {
 	return &i
 }
+
+// =============================================================================
+// ListAllFindings Tests
+// =============================================================================
+
+func TestClient_ListAllFindings(t *testing.T) {
+	// Setup mock server that returns both review comments and issue comments
+	reviewComments := []PullRequestComment{
+		{
+			ID:          1001,
+			Body:        "**Severity: high**\nReview comment\n<!-- CR_FP:abc123def456abc123def456abc12345 -->",
+			Path:        "main.go",
+			Line:        intPtr(10),
+			User:        User{Login: "bot", Type: "Bot"},
+			CreatedAt:   "2024-01-15T10:00:00Z",
+			InReplyToID: 0,
+		},
+	}
+
+	issueComments := []IssueComment{
+		{
+			ID:        2001,
+			Body:      "**⚠️ Finding Outside Diff**\n\n📁 `deleted.go` (line 50)\n\n**Severity: medium**\n\nOut of diff finding\n\n<!-- CR_FP:def456abc123def456abc123def45678 CR_OOD:true CR_FILE:deleted.go CR_LINE:50 -->",
+			User:      User{Login: "github-actions[bot]", Type: "Bot"},
+			CreatedAt: "2024-01-15T11:00:00Z",
+		},
+		{
+			ID:        2002,
+			Body:      "Regular issue comment without markers",
+			User:      User{Login: "developer", Type: "User"},
+			CreatedAt: "2024-01-15T12:00:00Z",
+		},
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		// Route based on path
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42/comments":
+			_ = json.NewEncoder(w).Encode(reviewComments)
+		case "/repos/owner/repo/issues/42/comments":
+			_ = json.NewEncoder(w).Encode(issueComments)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	client.SetBaseURL(server.URL)
+	client.SetMaxRetries(0)
+
+	findings, err := client.ListAllFindings(context.Background(), "owner", "repo", 42, true)
+	require.NoError(t, err)
+
+	// Should have 2 findings: 1 review comment + 1 issue comment with fingerprint
+	// The regular issue comment (2002) should be filtered out
+	assert.Len(t, findings, 2)
+
+	// Verify in-diff finding (review comment)
+	var inDiffFinding, outDiffFinding *domain.PRFinding
+	for i := range findings {
+		if findings[i].IsOutOfDiff {
+			outDiffFinding = &findings[i]
+		} else {
+			inDiffFinding = &findings[i]
+		}
+	}
+
+	require.NotNil(t, inDiffFinding, "should have in-diff finding")
+	assert.Equal(t, int64(1001), inDiffFinding.CommentID)
+	assert.Equal(t, "main.go", inDiffFinding.Path)
+	assert.Equal(t, 10, inDiffFinding.Line)
+	assert.False(t, inDiffFinding.IsOutOfDiff)
+
+	require.NotNil(t, outDiffFinding, "should have out-of-diff finding")
+	assert.Equal(t, int64(2001), outDiffFinding.CommentID)
+	assert.Equal(t, "deleted.go", outDiffFinding.Path)
+	assert.Equal(t, 50, outDiffFinding.Line)
+	assert.True(t, outDiffFinding.IsOutOfDiff)
+	assert.Equal(t, "medium", outDiffFinding.Severity)
+}
+
+func TestClient_ListAllFindings_WithReplies(t *testing.T) {
+	reviewComments := []PullRequestComment{}
+
+	issueComments := []IssueComment{
+		{
+			ID:        2001,
+			Body:      "OOD finding\n<!-- CR_FP:abc123def456abc123def456abc12345 CR_OOD:true CR_FILE:file.go CR_LINE:10 -->",
+			User:      User{Login: "bot", Type: "Bot"},
+			CreatedAt: "2024-01-15T10:00:00Z",
+		},
+		{
+			ID:        2002,
+			Body:      "<!-- CR_REPLY_TO:abc123def456abc123def456abc12345 -->\n\n> Replying to finding in `file.go`\n\nFixed!",
+			User:      User{Login: "developer", Type: "User"},
+			CreatedAt: "2024-01-15T11:00:00Z",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42/comments":
+			_ = json.NewEncoder(w).Encode(reviewComments)
+		case "/repos/owner/repo/issues/42/comments":
+			_ = json.NewEncoder(w).Encode(issueComments)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	client.SetBaseURL(server.URL)
+	client.SetMaxRetries(0)
+
+	findings, err := client.ListAllFindings(context.Background(), "owner", "repo", 42, true)
+	require.NoError(t, err)
+
+	// Should have 1 finding (the OOD finding, not the reply)
+	assert.Len(t, findings, 1)
+	assert.Equal(t, int64(2001), findings[0].CommentID)
+	assert.Equal(t, 1, findings[0].ReplyCount)
+	assert.True(t, findings[0].HasReply)
+}
+
+func TestIssueCommentToFinding(t *testing.T) {
+	comment := IssueComment{
+		ID:        2001,
+		Body:      "**⚠️ Finding Outside Diff**\n\n📁 `auth/handler.go` (line 142)\n\n**Severity: high** | **Category: security**\n\nSQL injection\n\n<!-- CR_FP:abc123def456abc123def456abc12345 CR_OOD:true CR_FILE:auth/handler.go CR_LINE:142 CR_REVIEWER:security -->",
+		User:      User{Login: "github-actions[bot]", Type: "Bot"},
+		CreatedAt: "2024-01-15T10:00:00Z",
+	}
+
+	meta := replyMetadata{count: 2}
+	finding := issueCommentToFinding(comment, "abc123def456abc123def456abc12345", meta)
+
+	assert.Equal(t, int64(2001), finding.CommentID)
+	assert.Equal(t, "abc123def456abc123def456abc12345", finding.Fingerprint)
+	assert.Equal(t, "auth/handler.go", finding.Path)
+	assert.Equal(t, 142, finding.Line)
+	assert.Equal(t, "github-actions[bot]", finding.Author)
+	assert.Equal(t, "high", finding.Severity)
+	assert.Equal(t, "security", finding.Category)
+	assert.Equal(t, "security", finding.Reviewer)
+	assert.True(t, finding.IsOutOfDiff)
+	assert.Equal(t, 2, finding.ReplyCount)
+	assert.True(t, finding.HasReply)
+}
+
+func TestBuildIssueCommentReplyMap(t *testing.T) {
+	comments := []IssueComment{
+		{
+			ID:        2001,
+			Body:      "Finding\n<!-- CR_FP:abc123 CR_OOD:true -->",
+			User:      User{Login: "bot"},
+			CreatedAt: "2024-01-15T10:00:00Z",
+		},
+		{
+			ID:        2002,
+			Body:      "<!-- CR_REPLY_TO:abc123 -->\n\nReply 1",
+			User:      User{Login: "dev1"},
+			CreatedAt: "2024-01-15T11:00:00Z",
+		},
+		{
+			ID:        2003,
+			Body:      "<!-- CR_REPLY_TO:abc123 -->\n\nReply 2",
+			User:      User{Login: "dev2"},
+			CreatedAt: "2024-01-15T12:00:00Z",
+		},
+		{
+			ID:        2004,
+			Body:      "Finding 2\n<!-- CR_FP:def456 CR_OOD:true -->",
+			User:      User{Login: "bot"},
+			CreatedAt: "2024-01-15T13:00:00Z",
+		},
+	}
+
+	metadata := buildIssueCommentReplyMap(comments)
+
+	// abc123 has 2 replies
+	assert.Equal(t, 2, metadata["abc123"].count)
+	assert.Equal(t, "dev2", metadata["abc123"].lastReplyBy) // dev2 posted last
+
+	// def456 has no replies
+	assert.Equal(t, 0, metadata["def456"].count)
+}

--- a/internal/adapter/github/request_builder.go
+++ b/internal/adapter/github/request_builder.go
@@ -33,6 +33,18 @@ const costMarkerStart = "<!-- CR_COST:"
 // costMarkerEnd closes the cost HTML comment.
 const costMarkerEnd = " -->"
 
+// outOfDiffMarkerPrefix marks findings posted as issue comments (outside PR diff).
+const outOfDiffMarkerPrefix = " CR_OOD:"
+
+// fileMarkerPrefix embeds the file path in issue comments for out-of-diff findings.
+const fileMarkerPrefix = " CR_FILE:"
+
+// lineMarkerPrefix embeds the line number in issue comments for out-of-diff findings.
+const lineMarkerPrefix = " CR_LINE:"
+
+// replyToMarkerStart is the prefix for linking issue comment replies to parent findings.
+const replyToMarkerStart = "<!-- CR_REPLY_TO:"
+
 // ReviewActions configures the GitHub review action for each finding severity level.
 // This mirrors config.ReviewActions but lives in the adapter layer to avoid coupling.
 type ReviewActions struct {
@@ -276,12 +288,17 @@ func ExtractFingerprintFromComment(body string) (domain.FindingFingerprint, bool
 		return "", false
 	}
 
-	// Extract content between markers (may include reviewer tag)
+	// Extract content between markers (may include reviewer/OOD tags)
 	content := remaining[:endIdx]
 
 	// If there's a reviewer tag, fingerprint is before it
 	if reviewerIdx := strings.Index(content, reviewerMarkerPrefix); reviewerIdx != -1 {
 		content = content[:reviewerIdx]
+	}
+
+	// If there's an out-of-diff tag, fingerprint is before it
+	if oodIdx := strings.Index(content, outOfDiffMarkerPrefix); oodIdx != -1 {
+		content = content[:oodIdx]
 	}
 
 	// Extract, trim, and normalize case (fingerprints are stored lowercase internally,
@@ -644,4 +661,158 @@ func ExtractCostFromReview(body string) (float64, bool) {
 	}
 
 	return cost, true
+}
+
+// =============================================================================
+// Out-of-Diff Finding Helpers
+// =============================================================================
+
+// FormatOutOfDiffFindingComment formats a finding for posting as an issue comment.
+// Unlike regular review comments, issue comments don't have file path and line number
+// metadata from GitHub, so we embed them in the comment body along with the CR_OOD marker.
+//
+// Format includes:
+// - Standard finding content (severity, category, description, suggestion)
+// - Fingerprint marker (CR_FP:xxx)
+// - Out-of-diff marker (CR_OOD:true)
+// - File path (CR_FILE:path/to/file.go)
+// - Line number (CR_LINE:42)
+// - Optional reviewer marker (CR_REVIEWER:security)
+func FormatOutOfDiffFindingComment(f domain.Finding, fingerprint domain.FindingFingerprint, actions ReviewActions) string {
+	var sb strings.Builder
+
+	// Add header explaining this is an out-of-diff finding
+	sb.WriteString("**⚠️ Finding Outside Diff**\n\n")
+	sb.WriteString(fmt.Sprintf("📁 `%s` (line %d)\n\n", f.File, f.LineStart))
+
+	// Add standard finding format
+	sb.WriteString(FormatFindingCommentWithActions(f, actions))
+
+	// Add metadata markers in hidden HTML comment
+	sb.WriteString("\n")
+	sb.WriteString(fingerprintMarkerStart)
+	sb.WriteString(string(fingerprint))
+	sb.WriteString(outOfDiffMarkerPrefix)
+	sb.WriteString("true")
+	sb.WriteString(fileMarkerPrefix)
+	sb.WriteString(f.File)
+	sb.WriteString(lineMarkerPrefix)
+	sb.WriteString(fmt.Sprintf("%d", f.LineStart))
+
+	// Include reviewer name if present
+	if f.ReviewerName != "" {
+		sb.WriteString(reviewerMarkerPrefix)
+		sb.WriteString(f.ReviewerName)
+	}
+
+	sb.WriteString(fingerprintMarkerEnd)
+
+	return sb.String()
+}
+
+// ExtractOutOfDiffMarker returns true if the comment body contains CR_OOD:true marker.
+// This indicates the comment was posted as an issue comment for an out-of-diff finding.
+func ExtractOutOfDiffMarker(body string) bool {
+	return strings.Contains(body, outOfDiffMarkerPrefix+"true")
+}
+
+// ExtractFileLineFromComment extracts file path and line number from an out-of-diff
+// finding comment. Returns (file, line, true) if both markers are found and valid,
+// or ("", 0, false) otherwise.
+func ExtractFileLineFromComment(body string) (file string, line int, ok bool) {
+	// Find file marker
+	fileIdx := strings.Index(body, fileMarkerPrefix)
+	if fileIdx == -1 {
+		return "", 0, false
+	}
+
+	fileStart := fileIdx + len(fileMarkerPrefix)
+
+	// Find the end of the file path (at the next marker or end of comment)
+	remaining := body[fileStart:]
+	fileEnd := len(remaining)
+
+	// File ends at the next marker (CR_LINE, CR_REVIEWER, or -->)
+	for _, marker := range []string{lineMarkerPrefix, reviewerMarkerPrefix, fingerprintMarkerEnd} {
+		if idx := strings.Index(remaining, marker); idx != -1 && idx < fileEnd {
+			fileEnd = idx
+		}
+	}
+
+	file = strings.TrimSpace(remaining[:fileEnd])
+	if file == "" {
+		return "", 0, false
+	}
+
+	// Find line marker
+	lineIdx := strings.Index(body, lineMarkerPrefix)
+	if lineIdx == -1 {
+		return "", 0, false
+	}
+
+	lineStart := lineIdx + len(lineMarkerPrefix)
+	remaining = body[lineStart:]
+
+	// Parse line number (ends at next marker or end)
+	lineEnd := 0
+	for lineEnd < len(remaining) && remaining[lineEnd] >= '0' && remaining[lineEnd] <= '9' {
+		lineEnd++
+	}
+
+	if lineEnd == 0 {
+		return "", 0, false
+	}
+
+	_, err := fmt.Sscanf(remaining[:lineEnd], "%d", &line)
+	if err != nil {
+		return "", 0, false
+	}
+
+	return file, line, true
+}
+
+// FormatReplyToOutOfDiffFinding formats a reply to an out-of-diff finding.
+// Since GitHub issue comments don't have native threading, we include a reference
+// marker (CR_REPLY_TO:fingerprint) to track reply relationships programmatically.
+func FormatReplyToOutOfDiffFinding(fingerprint, file, body string) string {
+	var sb strings.Builder
+
+	// Add reply-to marker
+	sb.WriteString(replyToMarkerStart)
+	sb.WriteString(fingerprint)
+	sb.WriteString(fingerprintMarkerEnd)
+	sb.WriteString("\n\n")
+
+	// Add quote context
+	sb.WriteString(fmt.Sprintf("> Replying to finding in `%s`\n\n", file))
+
+	// Add the actual reply content
+	sb.WriteString(body)
+
+	return sb.String()
+}
+
+// ExtractReplyToMarker extracts the fingerprint from a CR_REPLY_TO marker.
+// Returns (fingerprint, true) if found and non-empty, or ("", false) otherwise.
+// This is used to build reply chains for out-of-diff findings.
+func ExtractReplyToMarker(body string) (string, bool) {
+	startIdx := strings.Index(body, replyToMarkerStart)
+	if startIdx == -1 {
+		return "", false
+	}
+
+	contentStart := startIdx + len(replyToMarkerStart)
+	remaining := body[contentStart:]
+
+	endIdx := strings.Index(remaining, fingerprintMarkerEnd)
+	if endIdx == -1 {
+		return "", false
+	}
+
+	fp := strings.TrimSpace(remaining[:endIdx])
+	if fp == "" {
+		return "", false
+	}
+
+	return fp, true
 }

--- a/internal/adapter/github/request_builder_test.go
+++ b/internal/adapter/github/request_builder_test.go
@@ -1377,3 +1377,238 @@ without proper fingerprint markers`,
 		})
 	}
 }
+
+// =============================================================================
+// Out-of-Diff Finding Tests
+// =============================================================================
+
+func TestFormatOutOfDiffFindingComment(t *testing.T) {
+	finding := domain.Finding{
+		ID:          "test-id",
+		File:        "src/auth/handler.go",
+		LineStart:   142,
+		LineEnd:     142,
+		Severity:    "high",
+		Category:    "security",
+		Description: "SQL injection vulnerability in authentication handler",
+		Suggestion:  "Use parameterized queries",
+	}
+	fingerprint := domain.FingerprintFromFinding(finding)
+	actions := github.ReviewActions{}
+
+	comment := github.FormatOutOfDiffFindingComment(finding, fingerprint, actions)
+
+	// Should contain standard finding content
+	assert.Contains(t, comment, "**Severity:** high")
+	assert.Contains(t, comment, "**Category:** security")
+	assert.Contains(t, comment, "SQL injection vulnerability")
+	assert.Contains(t, comment, "Use parameterized queries")
+
+	// Should contain OOD marker
+	assert.Contains(t, comment, "CR_OOD:true")
+
+	// Should contain file and line markers
+	assert.Contains(t, comment, "CR_FILE:src/auth/handler.go")
+	assert.Contains(t, comment, "CR_LINE:142")
+
+	// Should contain fingerprint
+	assert.Contains(t, comment, "CR_FP:")
+}
+
+func TestFormatOutOfDiffFindingComment_WithReviewer(t *testing.T) {
+	finding := domain.Finding{
+		ID:           "test-id",
+		File:         "main.go",
+		LineStart:    50,
+		LineEnd:      55,
+		Severity:     "medium",
+		Category:     "maintainability",
+		Description:  "Long function should be refactored",
+		ReviewerName: "architecture",
+	}
+	fingerprint := domain.FingerprintFromFinding(finding)
+	actions := github.ReviewActions{}
+
+	comment := github.FormatOutOfDiffFindingComment(finding, fingerprint, actions)
+
+	// Should contain reviewer marker
+	assert.Contains(t, comment, "CR_REVIEWER:architecture")
+
+	// Should contain all other markers
+	assert.Contains(t, comment, "CR_OOD:true")
+	assert.Contains(t, comment, "CR_FILE:main.go")
+	assert.Contains(t, comment, "CR_LINE:50")
+}
+
+func TestExtractOutOfDiffMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "has OOD marker",
+			body: "Content\n<!-- CR_FP:abc123def456abc123def456abc12345 CR_OOD:true CR_FILE:main.go CR_LINE:42 -->",
+			want: true,
+		},
+		{
+			name: "no OOD marker",
+			body: "Content\n<!-- CR_FP:abc123def456abc123def456abc12345 CR_FILE:main.go CR_LINE:42 -->",
+			want: false,
+		},
+		{
+			name: "regular in-diff comment",
+			body: "Content\n<!-- CR_FP:abc123def456abc123def456abc12345 CR_REVIEWER:security -->",
+			want: false,
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: false,
+		},
+		{
+			name: "OOD marker with wrong value",
+			body: "Content\n<!-- CR_FP:abc CR_OOD:false -->",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := github.ExtractOutOfDiffMarker(tt.body)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractFileLineFromComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantFile string
+		wantLine int
+		wantOK   bool
+	}{
+		{
+			name:     "full OOD comment",
+			body:     "Content\n<!-- CR_FP:abc123 CR_OOD:true CR_FILE:src/auth/handler.go CR_LINE:142 -->",
+			wantFile: "src/auth/handler.go",
+			wantLine: 142,
+			wantOK:   true,
+		},
+		{
+			name:     "file with spaces in path",
+			body:     "<!-- CR_FILE:path/to/my file.go CR_LINE:50 -->",
+			wantFile: "path/to/my file.go",
+			wantLine: 50,
+			wantOK:   true,
+		},
+		{
+			name:     "no file marker",
+			body:     "<!-- CR_FP:abc123 CR_OOD:true CR_LINE:42 -->",
+			wantFile: "",
+			wantLine: 0,
+			wantOK:   false,
+		},
+		{
+			name:     "no line marker",
+			body:     "<!-- CR_FP:abc123 CR_OOD:true CR_FILE:main.go -->",
+			wantFile: "",
+			wantLine: 0,
+			wantOK:   false,
+		},
+		{
+			name:     "invalid line number",
+			body:     "<!-- CR_FILE:main.go CR_LINE:abc -->",
+			wantFile: "",
+			wantLine: 0,
+			wantOK:   false,
+		},
+		{
+			name:     "empty body",
+			body:     "",
+			wantFile: "",
+			wantLine: 0,
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, line, ok := github.ExtractFileLineFromComment(tt.body)
+			assert.Equal(t, tt.wantOK, ok, "ok mismatch")
+			if ok {
+				assert.Equal(t, tt.wantFile, file, "file mismatch")
+				assert.Equal(t, tt.wantLine, line, "line mismatch")
+			}
+		})
+	}
+}
+
+func TestFormatReplyToOutOfDiffFinding(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+		file        string
+		body        string
+		wantMarker  bool
+	}{
+		{
+			name:        "standard reply",
+			fingerprint: "abc123def456",
+			file:        "main.go",
+			body:        "This has been fixed in the latest commit.",
+			wantMarker:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reply := github.FormatReplyToOutOfDiffFinding(tt.fingerprint, tt.file, tt.body)
+
+			if tt.wantMarker {
+				assert.Contains(t, reply, "CR_REPLY_TO:"+tt.fingerprint)
+				assert.Contains(t, reply, tt.file)
+				assert.Contains(t, reply, tt.body)
+			}
+		})
+	}
+}
+
+func TestExtractReplyToMarker(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		wantFP string
+		wantOK bool
+	}{
+		{
+			name:   "has reply marker",
+			body:   "<!-- CR_REPLY_TO:abc123def456 -->\n\n> Replying to finding in `main.go`\n\nFixed!",
+			wantFP: "abc123def456",
+			wantOK: true,
+		},
+		{
+			name:   "no reply marker",
+			body:   "Regular comment without markers",
+			wantFP: "",
+			wantOK: false,
+		},
+		{
+			name:   "empty fingerprint in marker",
+			body:   "<!-- CR_REPLY_TO: -->",
+			wantFP: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp, ok := github.ExtractReplyToMarker(tt.body)
+			assert.Equal(t, tt.wantOK, ok, "ok mismatch")
+			if ok {
+				assert.Equal(t, tt.wantFP, fp, "fingerprint mismatch")
+			}
+		})
+	}
+}

--- a/internal/adapter/mcp/handlers.go
+++ b/internal/adapter/mcp/handlers.go
@@ -877,6 +877,13 @@ func computeFindingsSummary(findings []domain.PRFinding) *FindingsSummary {
 			summary.Unreplied++
 		}
 
+		// Track in-diff vs out-of-diff
+		if f.IsOutOfDiff {
+			summary.OutOfDiff++
+		} else {
+			summary.InDiff++
+		}
+
 		// Track by severity (use "unknown" for empty)
 		sev := f.Severity
 		if sev == "" {
@@ -908,6 +915,7 @@ func findingToOutput(f domain.PRFinding) PRFindingOutput {
 		HasReply:     f.HasReply,
 		LastReplyBy:  f.LastReplyBy,
 		ThreadStatus: f.ThreadStatus(),
+		IsOutOfDiff:  f.IsOutOfDiff,
 	}
 
 	// Format LastReplyAt as RFC3339 if present and non-zero

--- a/internal/adapter/mcp/handlers_test.go
+++ b/internal/adapter/mcp/handlers_test.go
@@ -105,6 +105,14 @@ func (m *MockCommentReader) ListPRComments(ctx context.Context, owner, repo stri
 	return args.Get(0).([]domain.PRFinding), args.Error(1)
 }
 
+func (m *MockCommentReader) ListAllFindings(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error) {
+	args := m.Called(ctx, owner, repo, prNumber, filterByFingerprint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.PRFinding), args.Error(1)
+}
+
 func (m *MockCommentReader) GetPRComment(ctx context.Context, owner, repo string, prNumber int, commentID int64) (*domain.PRFinding, error) {
 	args := m.Called(ctx, owner, repo, prNumber, commentID)
 	if args.Get(0) == nil {
@@ -526,7 +534,7 @@ func TestServer_handleListFindings(t *testing.T) {
 			{CommentID: 1, Fingerprint: "fp1", Path: "main.go", Line: 10, Severity: "high", Body: "Issue 1"},
 			{CommentID: 2, Fingerprint: "fp2", Path: "util.go", Line: 20, Severity: "medium", Body: "Issue 2"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -571,7 +579,7 @@ func TestServer_handleListFindings(t *testing.T) {
 			{CommentID: 2, Fingerprint: "fp2", Severity: "medium"},
 			{CommentID: 3, Fingerprint: "fp3", Severity: "high"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -618,7 +626,7 @@ func TestServer_handleListFindings(t *testing.T) {
 	t.Run("returns empty list when no findings", func(t *testing.T) {
 		mockComment := new(MockCommentReader)
 
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return([]domain.PRFinding{}, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return([]domain.PRFinding{}, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,

--- a/internal/adapter/mcp/integration_test.go
+++ b/internal/adapter/mcp/integration_test.go
@@ -97,6 +97,14 @@ func (m *MockIntegrationCommentReader) GetThreadHistory(ctx context.Context, own
 	return args.Get(0).([]domain.ThreadComment), args.Error(1)
 }
 
+func (m *MockIntegrationCommentReader) ListAllFindings(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error) {
+	args := m.Called(ctx, owner, repo, prNumber, filterByFingerprint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.PRFinding), args.Error(1)
+}
+
 // MockIntegrationCommentWriter provides mock comment write operations.
 type MockIntegrationCommentWriter struct {
 	mock.Mock
@@ -218,7 +226,7 @@ func TestIntegration_TriageWorkflow(t *testing.T) {
 	mockPR.On("GetPRMetadata", ctx, "testorg", "testrepo", 123).Return(prMeta, nil)
 	mockAnnotations.On("ListCheckRuns", ctx, "testorg", "testrepo", "abc123def", (*string)(nil)).Return(checkRuns, nil)
 	mockAnnotations.On("GetAnnotations", ctx, "testorg", "testrepo", int64(1001)).Return(annotations, nil)
-	mockComments.On("ListPRComments", ctx, "testorg", "testrepo", 123, true).Return(findings, nil)
+	mockComments.On("ListAllFindings", ctx, "testorg", "testrepo", 123, true).Return(findings, nil)
 	mockComments.On("GetPRCommentByFingerprint", ctx, "testorg", "testrepo", 123, "abc123").Return(&findings[0], nil)
 	mockCommentWriter.On("ReplyToComment", ctx, "testorg", "testrepo", 123, int64(2001), mock.AnythingOfType("string")).Return(int64(3001), nil)
 	// Note: FindThreadForComment is not called by reply - it's used by get_thread handler
@@ -358,7 +366,7 @@ func TestIntegration_ErrorPropagation(t *testing.T) {
 
 	t.Run("comment reader error propagates to handler", func(t *testing.T) {
 		mockComments := new(MockIntegrationCommentReader)
-		mockComments.On("ListPRComments", ctx, "testorg", "testrepo", 123, true).Return(nil, assert.AnError)
+		mockComments.On("ListAllFindings", ctx, "testorg", "testrepo", 123, true).Return(nil, assert.AnError)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComments,
@@ -373,7 +381,7 @@ func TestIntegration_ErrorPropagation(t *testing.T) {
 
 		_, _, err := server.handleListFindings(ctx, nil, input)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "list PR comments")
+		assert.Contains(t, err.Error(), "list findings")
 	})
 }
 

--- a/internal/adapter/mcp/review_handlers_test.go
+++ b/internal/adapter/mcp/review_handlers_test.go
@@ -72,6 +72,10 @@ func (m *mockCommentReaderForDedup) GetThreadHistory(ctx context.Context, owner,
 	return nil, nil
 }
 
+func (m *mockCommentReaderForDedup) ListAllFindings(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error) {
+	return m.findings, m.err
+}
+
 // createPRServiceForDedup creates a PRService with a mock CommentReader for testing skip_duplicates.
 func createPRServiceForDedup(findings []domain.PRFinding) *triage.PRService {
 	return triage.NewPRService(triage.PRServiceDeps{

--- a/internal/adapter/mcp/server.go
+++ b/internal/adapter/mcp/server.go
@@ -226,6 +226,8 @@ type FindingsSummary struct {
 	Total         int            `json:"total"`
 	Replied       int            `json:"replied"`
 	Unreplied     int            `json:"unreplied"`
+	InDiff        int            `json:"in_diff"`     // Findings with diff position (review comments)
+	OutOfDiff     int            `json:"out_of_diff"` // Findings without diff position (issue comments)
 	BySeverity    map[string]int `json:"by_severity"`
 	TriagePercent float64        `json:"triage_percent"`
 }
@@ -246,6 +248,7 @@ type PRFindingOutput struct {
 	LastReplyAt  *string `json:"last_reply_at,omitempty"`
 	LastReplyBy  string  `json:"last_reply_by,omitempty"`
 	ThreadStatus string  `json:"thread_status"`
+	IsOutOfDiff  bool    `json:"is_out_of_diff"` // True if finding is from an issue comment (outside PR diff)
 }
 
 // GetFindingInput is the input for the get_finding tool.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,6 +288,15 @@ type ReviewConfig struct {
 	// Default: 0 (unlimited - all reviewers run in parallel)
 	// Recommended: 3-5 for most deployments
 	MaxConcurrentReviewers int `yaml:"maxConcurrentReviewers"`
+
+	// PostOutOfDiffAsComments enables posting out-of-diff findings as individual
+	// issue comments rather than only including them in the summary.
+	// Out-of-diff findings are on lines not included in the PR diff (deleted lines,
+	// unchanged context) and cannot be posted as inline review comments.
+	// When enabled, these findings are posted as issue comments with fingerprint
+	// markers, making them visible to MCP tools for triage.
+	// Default: true (enabled by default)
+	PostOutOfDiffAsComments *bool `yaml:"postOutOfDiffAsComments,omitempty"`
 }
 
 // ReviewActions maps finding severities to GitHub review actions.
@@ -311,6 +320,15 @@ type ReviewActions struct {
 	// OnNonBlocking is the action when findings exist but none trigger REQUEST_CHANGES.
 	// This allows posting APPROVE with informational comments for low-severity issues.
 	OnNonBlocking string `yaml:"onNonBlocking"`
+}
+
+// ShouldPostOutOfDiff returns whether out-of-diff findings should be posted as individual
+// issue comments. Defaults to true if not explicitly set.
+func (c ReviewConfig) ShouldPostOutOfDiff() bool {
+	if c.PostOutOfDiffAsComments == nil {
+		return true // Default enabled
+	}
+	return *c.PostOutOfDiffAsComments
 }
 
 // VerificationConfig configures the agent verification behavior.
@@ -555,6 +573,16 @@ func chooseReview(base, overlay ReviewConfig) ReviewConfig {
 
 	// AlwaysBlockCategories: union of base and overlay (additive)
 	result.AlwaysBlockCategories = mergeCategories(base.AlwaysBlockCategories, overlay.AlwaysBlockCategories)
+
+	// MaxConcurrentReviewers: overlay wins if non-zero
+	if overlay.MaxConcurrentReviewers != 0 {
+		result.MaxConcurrentReviewers = overlay.MaxConcurrentReviewers
+	}
+
+	// PostOutOfDiffAsComments: overlay wins if set (not nil)
+	if overlay.PostOutOfDiffAsComments != nil {
+		result.PostOutOfDiffAsComments = overlay.PostOutOfDiffAsComments
+	}
 
 	return result
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1502,3 +1502,110 @@ defaultReviewers:
 		t.Errorf("expected second default reviewer 'maintainability', got %s", cfg.DefaultReviewers[1])
 	}
 }
+
+// PostOutOfDiffAsComments tests
+
+func TestPostOutOfDiffAsComments_DefaultsToTrue(t *testing.T) {
+	// ReviewConfig with nil PostOutOfDiffAsComments should default to true
+	cfg := config.ReviewConfig{}
+
+	if !cfg.ShouldPostOutOfDiff() {
+		t.Error("expected ShouldPostOutOfDiff() to return true by default")
+	}
+}
+
+func TestPostOutOfDiffAsComments_ExplicitTrue(t *testing.T) {
+	enabled := true
+	cfg := config.ReviewConfig{
+		PostOutOfDiffAsComments: &enabled,
+	}
+
+	if !cfg.ShouldPostOutOfDiff() {
+		t.Error("expected ShouldPostOutOfDiff() to return true when explicitly set")
+	}
+}
+
+func TestPostOutOfDiffAsComments_ExplicitFalse(t *testing.T) {
+	disabled := false
+	cfg := config.ReviewConfig{
+		PostOutOfDiffAsComments: &disabled,
+	}
+
+	if cfg.ShouldPostOutOfDiff() {
+		t.Error("expected ShouldPostOutOfDiff() to return false when explicitly disabled")
+	}
+}
+
+func TestPostOutOfDiffAsComments_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "bop.yaml")
+	content := `
+review:
+  postOutOfDiffAsComments: false
+`
+	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := config.Load(config.LoaderOptions{
+		ConfigPaths: []string{dir},
+		FileName:    "bop",
+		EnvPrefix:   "CR_TEST_OOD_FILE",
+	})
+	if err != nil {
+		t.Fatalf("load returned error: %v", err)
+	}
+
+	if cfg.Review.ShouldPostOutOfDiff() {
+		t.Error("expected ShouldPostOutOfDiff() to return false from file config")
+	}
+}
+
+func TestPostOutOfDiffAsComments_MergeOverlayWins(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	base := config.Config{
+		Review: config.ReviewConfig{
+			PostOutOfDiffAsComments: &enabled,
+		},
+	}
+	overlay := config.Config{
+		Review: config.ReviewConfig{
+			PostOutOfDiffAsComments: &disabled,
+		},
+	}
+
+	merged, err := config.Merge(base, overlay)
+	if err != nil {
+		t.Fatalf("Merge returned error: %v", err)
+	}
+
+	if merged.Review.ShouldPostOutOfDiff() {
+		t.Error("expected ShouldPostOutOfDiff() to return false from overlay")
+	}
+}
+
+func TestPostOutOfDiffAsComments_MergePreservesBase(t *testing.T) {
+	disabled := false
+
+	base := config.Config{
+		Review: config.ReviewConfig{
+			PostOutOfDiffAsComments: &disabled,
+		},
+	}
+	overlay := config.Config{
+		Review: config.ReviewConfig{
+			// No PostOutOfDiffAsComments set - should preserve base
+		},
+	}
+
+	merged, err := config.Merge(base, overlay)
+	if err != nil {
+		t.Fatalf("Merge returned error: %v", err)
+	}
+
+	if merged.Review.ShouldPostOutOfDiff() {
+		t.Error("expected ShouldPostOutOfDiff() to return false (preserved from base)")
+	}
+}

--- a/internal/domain/annotation.go
+++ b/internal/domain/annotation.go
@@ -243,6 +243,12 @@ type PRFinding struct {
 	// Reviewer is the persona name extracted from the comment body (if present).
 	// This is set from the CR_REVIEWER marker in Phase 3.2 findings.
 	Reviewer string `json:"reviewer,omitempty"`
+
+	// IsOutOfDiff indicates this finding came from an issue comment rather than
+	// a review comment because the line is not in the PR diff. Out-of-diff findings
+	// are posted as issue comments with CR_OOD:true markers since GitHub's review
+	// comment API requires a valid diff position.
+	IsOutOfDiff bool `json:"isOutOfDiff,omitempty"`
 }
 
 // ThreadStatus returns the discussion status of this finding.

--- a/internal/domain/annotation_test.go
+++ b/internal/domain/annotation_test.go
@@ -359,3 +359,33 @@ func TestPRMetadata(t *testing.T) {
 	assert.Equal(t, "delightfulhammers/bop", meta.FullName())
 	assert.True(t, meta.IsOpen())
 }
+
+func TestPRFinding_IsOutOfDiff(t *testing.T) {
+	tests := []struct {
+		name        string
+		finding     PRFinding
+		wantOutDiff bool
+	}{
+		{
+			name:        "default is false (in-diff)",
+			finding:     PRFinding{CommentID: 123},
+			wantOutDiff: false,
+		},
+		{
+			name:        "explicitly set to true",
+			finding:     PRFinding{CommentID: 456, IsOutOfDiff: true},
+			wantOutDiff: true,
+		},
+		{
+			name:        "explicitly set to false",
+			finding:     PRFinding{CommentID: 789, IsOutOfDiff: false},
+			wantOutDiff: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantOutDiff, tt.finding.IsOutOfDiff)
+		})
+	}
+}

--- a/internal/usecase/github/poster.go
+++ b/internal/usecase/github/poster.go
@@ -21,14 +21,23 @@ type ReviewClient interface {
 	ListPullRequestComments(ctx context.Context, owner, repo string, pullNumber int) ([]github.PullRequestComment, error)
 }
 
+// IssueCommentClient defines the interface for posting issue comments.
+// Issue comments are used for out-of-diff findings since they don't require diff positions.
+// This interface allows for mocking in tests.
+type IssueCommentClient interface {
+	CreateIssueComment(ctx context.Context, owner, repo string, prNumber int, body string) (int64, error)
+	ListIssueComments(ctx context.Context, owner, repo string, prNumber int) ([]github.IssueComment, error)
+}
+
 // ReviewPoster orchestrates posting code review findings to GitHub as PR reviews.
 // It determines the appropriate review event based on finding severities,
 // filters out findings that are not in the diff, and delegates the actual
 // API call to the ReviewClient.
 type ReviewPoster struct {
-	client           ReviewClient
-	semanticComparer dedup.SemanticComparer
-	semanticConfig   SemanticDedupConfig
+	client             ReviewClient
+	issueCommentClient IssueCommentClient
+	semanticComparer   dedup.SemanticComparer
+	semanticConfig     SemanticDedupConfig
 }
 
 // SemanticDedupConfig configures semantic deduplication behavior.
@@ -56,6 +65,15 @@ func WithSemanticComparer(comparer dedup.SemanticComparer, config SemanticDedupC
 	return func(p *ReviewPoster) {
 		p.semanticComparer = comparer
 		p.semanticConfig = config
+	}
+}
+
+// WithIssueCommentClient sets the client for posting out-of-diff findings as issue comments.
+// If set, out-of-diff findings are posted as individual issue comments in the PR conversation
+// immediately after the review is created.
+func WithIssueCommentClient(client IssueCommentClient) ReviewPosterOption {
+	return func(p *ReviewPoster) {
+		p.issueCommentClient = client
 	}
 }
 
@@ -111,6 +129,13 @@ type PostReviewRequest struct {
 	// Cost is the total cost of this review in USD.
 	// Used for cost tracking in the summary.
 	Cost float64
+
+	// PostOutOfDiffAsComments enables posting out-of-diff findings as individual
+	// issue comments rather than only including them in the summary section.
+	// When enabled, these findings appear immediately after the review in the
+	// PR conversation and are visible to MCP triage tools.
+	// Requires IssueCommentClient to be configured on the ReviewPoster.
+	PostOutOfDiffAsComments bool
 }
 
 // PostReviewResult contains the result of posting a review.
@@ -176,6 +201,13 @@ type PostReviewResult struct {
 
 	// CumulativeCost is the total cost across all reviews (CurrentCost + PriorCost).
 	CumulativeCost float64
+
+	// Out-of-diff tracking fields
+	// OutOfDiffPosted is the number of out-of-diff findings posted as issue comments.
+	OutOfDiffPosted int
+
+	// OutOfDiffSkipped is the number of out-of-diff findings skipped (already posted).
+	OutOfDiffSkipped int
 }
 
 // PostReview posts a code review to GitHub.
@@ -349,6 +381,18 @@ func (p *ReviewPoster) PostReview(ctx context.Context, req PostReviewRequest) (*
 		return nil, fmt.Errorf("CreateReview returned nil response")
 	}
 
+	// Post out-of-diff findings as issue comments immediately after the review.
+	// This ensures they appear in the conversation right after the summary comment.
+	// Use req.Findings (original) to capture all out-of-diff findings, even those
+	// that were deduplicated from the inline comments.
+	var outOfDiffPosted, outOfDiffSkipped int
+	if req.PostOutOfDiffAsComments {
+		outOfDiffPosted, outOfDiffSkipped = p.postOutOfDiffFindings(
+			ctx, req.Owner, req.Repo, req.PullNumber,
+			req.Findings, req.ReviewActions, req.BotUsername,
+		)
+	}
+
 	// Dismiss previous bot reviews AFTER successful post
 	// This ensures PR always has review signal - if post failed, old reviews remain
 	// Pass the new review ID to avoid dismissing the review we just created
@@ -382,6 +426,8 @@ func (p *ReviewPoster) PostReview(ctx context.Context, req PostReviewRequest) (*
 		CurrentCost:               costStats.CurrentCost,
 		PriorCost:                 costStats.PriorCost,
 		CumulativeCost:            costStats.CumulativeCost,
+		OutOfDiffPosted:           outOfDiffPosted,
+		OutOfDiffSkipped:          outOfDiffSkipped,
 	}, nil
 }
 
@@ -1014,4 +1060,91 @@ func extractExistingFindings(comments []github.PullRequestComment, botUsername s
 	}
 
 	return existing
+}
+
+// postOutOfDiffFindings posts out-of-diff findings as individual issue comments.
+// These findings don't have a valid diff position, so they can't be posted as
+// inline review comments. Instead, they're posted to the PR conversation thread
+// immediately after the review.
+//
+// Returns the count of findings posted and skipped (already exist).
+// Errors for individual comments are logged but don't stop processing.
+func (p *ReviewPoster) postOutOfDiffFindings(
+	ctx context.Context,
+	owner, repo string,
+	prNumber int,
+	findings []github.PositionedFinding,
+	actions github.ReviewActions,
+	botUsername string,
+) (posted int, skipped int) {
+	if p.issueCommentClient == nil {
+		return 0, 0
+	}
+
+	// Filter to only out-of-diff findings
+	var outOfDiffFindings []github.PositionedFinding
+	for _, pf := range findings {
+		if !pf.InDiff() {
+			outOfDiffFindings = append(outOfDiffFindings, pf)
+		}
+	}
+
+	if len(outOfDiffFindings) == 0 {
+		return 0, 0
+	}
+
+	// Fetch existing issue comments for deduplication
+	var existingFingerprints map[domain.FindingFingerprint]bool
+	if botUsername != "" {
+		issueComments, err := p.issueCommentClient.ListIssueComments(ctx, owner, repo, prNumber)
+		if err != nil {
+			log.Printf("warning: failed to fetch issue comments for dedup: %v", err)
+		} else {
+			existingFingerprints = extractIssueCommentFingerprints(issueComments, botUsername)
+		}
+	}
+
+	// Post each out-of-diff finding as an issue comment
+	for _, pf := range outOfDiffFindings {
+		fp := domain.FingerprintFromFinding(pf.Finding)
+
+		// Skip if already posted
+		if existingFingerprints != nil && existingFingerprints[fp] {
+			skipped++
+			continue
+		}
+
+		// Format the comment with prominent out-of-diff marker
+		body := github.FormatOutOfDiffFindingComment(pf.Finding, fp, actions)
+
+		_, err := p.issueCommentClient.CreateIssueComment(ctx, owner, repo, prNumber, body)
+		if err != nil {
+			log.Printf("warning: failed to post out-of-diff finding for %s: %v", pf.Finding.File, err)
+			continue
+		}
+		posted++
+	}
+
+	log.Printf("out-of-diff findings: %d posted, %d skipped (already exist)", posted, skipped)
+	return posted, skipped
+}
+
+// extractIssueCommentFingerprints extracts fingerprints from issue comments authored by the bot.
+// Returns a map of fingerprints for O(1) lookup.
+func extractIssueCommentFingerprints(comments []github.IssueComment, botUsername string) map[domain.FindingFingerprint]bool {
+	fingerprints := make(map[domain.FindingFingerprint]bool)
+
+	for _, comment := range comments {
+		// Skip comments not from the bot (case-insensitive)
+		if !strings.EqualFold(comment.User.Login, botUsername) {
+			continue
+		}
+
+		// Try to extract fingerprint from comment body
+		if fp, ok := github.ExtractFingerprintFromComment(comment.Body); ok {
+			fingerprints[fp] = true
+		}
+	}
+
+	return fingerprints
 }

--- a/internal/usecase/github/poster_test.go
+++ b/internal/usecase/github/poster_test.go
@@ -2131,3 +2131,212 @@ func TestReviewPoster_PostReview_DisputeInheritance_MixedFindings(t *testing.T) 
 	// Event determination uses original findings and their statuses
 	assert.Equal(t, github.EventRequestChanges, result.Event, "open high-severity finding should still block")
 }
+
+// ==== Out-of-Diff Findings Tests ====
+
+// MockIssueCommentClient is a mock implementation of the IssueCommentClient interface.
+type MockIssueCommentClient struct {
+	mu                     sync.Mutex
+	CreateIssueCommentFunc func(ctx context.Context, owner, repo string, prNumber int, body string) (int64, error)
+	ListIssueCommentsFunc  func(ctx context.Context, owner, repo string, prNumber int) ([]github.IssueComment, error)
+	CreatedComments        []string
+	NextCommentID          int64
+}
+
+func (m *MockIssueCommentClient) CreateIssueComment(ctx context.Context, owner, repo string, prNumber int, body string) (int64, error) {
+	m.mu.Lock()
+	m.CreatedComments = append(m.CreatedComments, body)
+	m.NextCommentID++
+	id := m.NextCommentID
+	m.mu.Unlock()
+	if m.CreateIssueCommentFunc != nil {
+		return m.CreateIssueCommentFunc(ctx, owner, repo, prNumber, body)
+	}
+	return id, nil
+}
+
+func (m *MockIssueCommentClient) ListIssueComments(ctx context.Context, owner, repo string, prNumber int) ([]github.IssueComment, error) {
+	if m.ListIssueCommentsFunc != nil {
+		return m.ListIssueCommentsFunc(ctx, owner, repo, prNumber)
+	}
+	return []github.IssueComment{}, nil
+}
+
+// GetCreatedComments returns a copy of created comments in a thread-safe manner.
+func (m *MockIssueCommentClient) GetCreatedComments() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]string, len(m.CreatedComments))
+	copy(result, m.CreatedComments)
+	return result
+}
+
+func TestReviewPoster_PostReview_PostsOutOfDiffAsIssueComments(t *testing.T) {
+	// Test that out-of-diff findings are posted as issue comments when enabled.
+	findingInDiff := makeFinding("in_diff.go", 10, "high", "In diff finding")
+	findingOutOfDiff := makeFinding("out_of_diff.go", 20, "medium", "Out of diff finding")
+
+	mockReviewClient := &MockReviewClient{
+		CreateReviewFunc: func(ctx context.Context, input github.CreateReviewInput) (*github.CreateReviewResponse, error) {
+			return &github.CreateReviewResponse{ID: 123, State: "COMMENTED"}, nil
+		},
+	}
+	mockIssueClient := &MockIssueCommentClient{}
+
+	poster := usecasegithub.NewReviewPoster(mockReviewClient,
+		usecasegithub.WithIssueCommentClient(mockIssueClient),
+	)
+
+	// In-diff finding has a position, out-of-diff does not
+	findings := []github.PositionedFinding{
+		{Finding: findingInDiff, DiffPosition: diff.IntPtr(5)}, // In diff
+		{Finding: findingOutOfDiff, DiffPosition: nil},         // Out of diff
+	}
+
+	result, err := poster.PostReview(context.Background(), usecasegithub.PostReviewRequest{
+		Owner:                   "owner",
+		Repo:                    "repo",
+		PullNumber:              1,
+		CommitSHA:               "sha",
+		Findings:                findings,
+		BotUsername:             "bot[bot]",
+		PostOutOfDiffAsComments: true,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.CommentsPosted, "1 in-diff finding should be posted as inline comment")
+	assert.Equal(t, 1, result.OutOfDiffPosted, "1 out-of-diff finding should be posted as issue comment")
+	assert.Equal(t, 0, result.OutOfDiffSkipped, "no out-of-diff findings should be skipped")
+
+	// Verify the issue comment contains the out-of-diff marker
+	comments := mockIssueClient.GetCreatedComments()
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0], "Finding Outside Diff")
+	assert.Contains(t, comments[0], "out_of_diff.go")
+	assert.Contains(t, comments[0], "CR_OOD:true")
+}
+
+func TestReviewPoster_PostReview_OutOfDiffDisabledByDefault(t *testing.T) {
+	// Test that out-of-diff findings are NOT posted when PostOutOfDiffAsComments is false.
+	findingOutOfDiff := makeFinding("out_of_diff.go", 20, "medium", "Out of diff finding")
+
+	mockReviewClient := &MockReviewClient{
+		CreateReviewFunc: func(ctx context.Context, input github.CreateReviewInput) (*github.CreateReviewResponse, error) {
+			return &github.CreateReviewResponse{ID: 123, State: "COMMENTED"}, nil
+		},
+	}
+	mockIssueClient := &MockIssueCommentClient{}
+
+	poster := usecasegithub.NewReviewPoster(mockReviewClient,
+		usecasegithub.WithIssueCommentClient(mockIssueClient),
+	)
+
+	findings := []github.PositionedFinding{
+		{Finding: findingOutOfDiff, DiffPosition: nil}, // Out of diff
+	}
+
+	result, err := poster.PostReview(context.Background(), usecasegithub.PostReviewRequest{
+		Owner:                   "owner",
+		Repo:                    "repo",
+		PullNumber:              1,
+		CommitSHA:               "sha",
+		Findings:                findings,
+		BotUsername:             "bot[bot]",
+		PostOutOfDiffAsComments: false, // Disabled
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.OutOfDiffPosted, "no out-of-diff findings should be posted when disabled")
+	assert.Equal(t, 0, result.OutOfDiffSkipped)
+
+	// No issue comments should have been created
+	comments := mockIssueClient.GetCreatedComments()
+	assert.Empty(t, comments)
+}
+
+func TestReviewPoster_PostReview_OutOfDiffDeduplicates(t *testing.T) {
+	// Test that out-of-diff findings are deduplicated against existing issue comments.
+	finding1 := makeFinding("old_finding.go", 10, "high", "Already posted")
+	finding2 := makeFinding("new_finding.go", 20, "medium", "New finding")
+
+	// Create fingerprint for the existing finding
+	fp1 := domain.FingerprintFromFinding(finding1)
+	existingCommentBody := "<!-- CR_FP:" + string(fp1) + " CR_OOD:true -->"
+
+	mockReviewClient := &MockReviewClient{
+		CreateReviewFunc: func(ctx context.Context, input github.CreateReviewInput) (*github.CreateReviewResponse, error) {
+			return &github.CreateReviewResponse{ID: 123, State: "COMMENTED"}, nil
+		},
+	}
+	mockIssueClient := &MockIssueCommentClient{
+		ListIssueCommentsFunc: func(ctx context.Context, owner, repo string, prNumber int) ([]github.IssueComment, error) {
+			return []github.IssueComment{
+				{
+					ID:   100,
+					Body: existingCommentBody,
+					User: github.User{Login: "bot[bot]", Type: "Bot"},
+				},
+			}, nil
+		},
+	}
+
+	poster := usecasegithub.NewReviewPoster(mockReviewClient,
+		usecasegithub.WithIssueCommentClient(mockIssueClient),
+	)
+
+	// Both findings are out of diff
+	findings := []github.PositionedFinding{
+		{Finding: finding1, DiffPosition: nil}, // Already exists
+		{Finding: finding2, DiffPosition: nil}, // New
+	}
+
+	result, err := poster.PostReview(context.Background(), usecasegithub.PostReviewRequest{
+		Owner:                   "owner",
+		Repo:                    "repo",
+		PullNumber:              1,
+		CommitSHA:               "sha",
+		Findings:                findings,
+		BotUsername:             "bot[bot]",
+		PostOutOfDiffAsComments: true,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.OutOfDiffPosted, "1 new out-of-diff finding should be posted")
+	assert.Equal(t, 1, result.OutOfDiffSkipped, "1 existing out-of-diff finding should be skipped")
+
+	// Only the new finding should have been posted
+	comments := mockIssueClient.GetCreatedComments()
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0], "new_finding.go")
+}
+
+func TestReviewPoster_PostReview_OutOfDiffWithoutIssueClient(t *testing.T) {
+	// Test that out-of-diff posting is silently skipped when IssueCommentClient is nil.
+	findingOutOfDiff := makeFinding("out_of_diff.go", 20, "medium", "Out of diff finding")
+
+	mockReviewClient := &MockReviewClient{
+		CreateReviewFunc: func(ctx context.Context, input github.CreateReviewInput) (*github.CreateReviewResponse, error) {
+			return &github.CreateReviewResponse{ID: 123, State: "COMMENTED"}, nil
+		},
+	}
+
+	// No IssueCommentClient configured
+	poster := usecasegithub.NewReviewPoster(mockReviewClient)
+
+	findings := []github.PositionedFinding{
+		{Finding: findingOutOfDiff, DiffPosition: nil},
+	}
+
+	result, err := poster.PostReview(context.Background(), usecasegithub.PostReviewRequest{
+		Owner:                   "owner",
+		Repo:                    "repo",
+		PullNumber:              1,
+		CommitSHA:               "sha",
+		Findings:                findings,
+		PostOutOfDiffAsComments: true, // Enabled, but no client
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.OutOfDiffPosted)
+	assert.Equal(t, 0, result.OutOfDiffSkipped)
+}

--- a/internal/usecase/triage/ports.go
+++ b/internal/usecase/triage/ports.go
@@ -32,6 +32,12 @@ type CommentReader interface {
 	// OR if they are from bot users. This ensures all automated review feedback is captured.
 	ListPRComments(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error)
 
+	// ListAllFindings retrieves both review comments AND issue comments with CR_FP markers.
+	// This provides a unified view of all findings, including out-of-diff findings posted
+	// as issue comments. Findings from issue comments will have IsOutOfDiff set to true.
+	// If filterByFingerprint is true, only comments with CR_FP markers are included.
+	ListAllFindings(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error)
+
 	// GetPRComment retrieves a single comment by ID.
 	// Returns ErrCommentNotFound if the comment doesn't exist or doesn't belong to the PR.
 	// The prNumber is required to validate the comment belongs to the expected PR.
@@ -103,6 +109,43 @@ type CommentWriter interface {
 	// Comments are placed on the RIGHT side of the diff (new file version).
 	// Returns the ID of the newly created comment.
 	CreateComment(ctx context.Context, owner, repo string, prNumber int, commitSHA, path string, line int, body string) (int64, error)
+}
+
+// IssueCommentWriter provides write access to PR issue comments (conversation thread).
+// Issue comments are different from review comments - they don't require a diff position,
+// making them suitable for out-of-diff findings.
+// This is a port that must be implemented by the GitHub adapter layer.
+type IssueCommentWriter interface {
+	// CreateIssueComment posts an issue comment on a PR (in the conversation thread).
+	// Unlike review comments, issue comments don't require a file path or line number.
+	// Returns the ID of the newly created comment.
+	CreateIssueComment(ctx context.Context, owner, repo string, prNumber int, body string) (int64, error)
+}
+
+// IssueCommentReader provides read access to PR issue comments (conversation thread).
+// Issue comments include both regular conversation and out-of-diff findings posted
+// with CR_OOD markers.
+// This is a port that must be implemented by the GitHub adapter layer.
+type IssueCommentReader interface {
+	// ListIssueComments retrieves all issue comments on a PR.
+	// Returns comments in chronological order (oldest first).
+	ListIssueComments(ctx context.Context, owner, repo string, prNumber int) ([]IssueComment, error)
+
+	// GetIssueComment retrieves a single issue comment by ID.
+	// Returns ErrCommentNotFound if the comment doesn't exist.
+	GetIssueComment(ctx context.Context, owner, repo string, commentID int64) (*IssueComment, error)
+}
+
+// IssueComment represents a GitHub issue comment (PR conversation comment).
+// Unlike review comments, issue comments don't have file paths or line numbers.
+type IssueComment struct {
+	ID          int64
+	Body        string
+	Author      string
+	AuthorType  string // "User" or "Bot"
+	CreatedAt   string
+	IsOutOfDiff bool   // True if this comment has CR_OOD:true marker
+	Fingerprint string // CR_FP marker value, if present
 }
 
 // ReviewManager provides operations for managing PR review state.

--- a/internal/usecase/triage/pr_service.go
+++ b/internal/usecase/triage/pr_service.go
@@ -19,8 +19,9 @@ type PRServiceDeps struct {
 	SuggestionExtractor SuggestionExtractor
 
 	// Write operations (optional - set to nil for read-only mode)
-	CommentWriter CommentWriter
-	ReviewManager ReviewManager
+	CommentWriter      CommentWriter
+	IssueCommentWriter IssueCommentWriter
+	ReviewManager      ReviewManager
 }
 
 // PRService implements read-only triage operations for a PR.
@@ -90,7 +91,9 @@ func (s *PRService) GetAnnotation(ctx context.Context, owner, repo string, check
 }
 
 // ListFindings returns all PR comments that are code reviewer findings.
-// Optionally filters by severity, category, and/or reply status.
+// This includes both in-diff findings (review comments) and out-of-diff findings
+// (issue comments with CR_OOD markers). Optionally filters by severity, category,
+// and/or reply status.
 func (s *PRService) ListFindings(ctx context.Context, owner, repo string, prNumber int, severity, category *string, replyStatus *ReplyStatus) ([]domain.PRFinding, error) {
 	if s.deps.CommentReader == nil {
 		return nil, ErrNotImplemented
@@ -106,10 +109,10 @@ func (s *PRService) ListFindings(ctx context.Context, owner, repo string, prNumb
 		return nil, fmt.Errorf("%w: reply_status %q (valid: %v)", ErrInvalidFilter, *replyStatus, ValidReplyStatuses)
 	}
 
-	// Get all comments with fingerprints (code reviewer findings)
-	findings, err := s.deps.CommentReader.ListPRComments(ctx, owner, repo, prNumber, true)
+	// Get all findings - both review comments (in-diff) and issue comments (out-of-diff)
+	findings, err := s.deps.CommentReader.ListAllFindings(ctx, owner, repo, prNumber, true)
 	if err != nil {
-		return nil, fmt.Errorf("list PR comments: %w", err)
+		return nil, fmt.Errorf("list findings: %w", err)
 	}
 
 	// Apply filters
@@ -286,18 +289,33 @@ func parseAnnotationID(id string) (checkRunID int64, index int, ok bool) {
 // ReplyToFinding posts a reply to a code reviewer finding.
 // The findingID can be a fingerprint (CR_FP:xxx) or a GitHub comment ID.
 // Returns the ID of the newly created reply comment.
+//
+// For out-of-diff findings (posted as issue comments), the reply is posted as
+// a new issue comment with a CR_REPLY_TO:fingerprint marker to track the relationship.
 func (s *PRService) ReplyToFinding(ctx context.Context, owner, repo string, prNumber int, findingID, body string) (int64, error) {
-	if s.deps.CommentWriter == nil {
-		return 0, ErrNotImplemented
-	}
 	if s.deps.CommentReader == nil {
 		return 0, fmt.Errorf("CommentReader required to look up finding: %w", ErrNotImplemented)
 	}
 
-	// Look up the finding to get its comment ID
+	// Look up the finding to get its details
 	finding, err := s.GetFinding(ctx, owner, repo, prNumber, findingID)
 	if err != nil {
 		return 0, fmt.Errorf("get finding: %w", err)
+	}
+
+	// Handle out-of-diff findings (posted as issue comments)
+	if finding.IsOutOfDiff {
+		if s.deps.IssueCommentWriter == nil {
+			return 0, fmt.Errorf("IssueCommentWriter required for out-of-diff replies: %w", ErrNotImplemented)
+		}
+		// Format reply with CR_REPLY_TO marker
+		replyBody := formatOutOfDiffReply(finding.Fingerprint, finding.Path, body)
+		return s.deps.IssueCommentWriter.CreateIssueComment(ctx, owner, repo, prNumber, replyBody)
+	}
+
+	// In-diff findings use review comment replies
+	if s.deps.CommentWriter == nil {
+		return 0, ErrNotImplemented
 	}
 
 	// SARIF annotations have CommentID=0 since they're not PR comments.
@@ -309,6 +327,12 @@ func (s *PRService) ReplyToFinding(ctx context.Context, owner, repo string, prNu
 
 	// Reply to the finding's comment
 	return s.deps.CommentWriter.ReplyToComment(ctx, owner, repo, prNumber, finding.CommentID, body)
+}
+
+// formatOutOfDiffReply formats a reply to an out-of-diff finding.
+// The reply includes a CR_REPLY_TO marker to track the relationship.
+func formatOutOfDiffReply(fingerprint, file, body string) string {
+	return fmt.Sprintf("**Re: %s**\n\n%s\n\n<!-- CR_REPLY_TO:%s -->", file, body, fingerprint)
 }
 
 // PostComment creates a new review comment at a specific file and line.

--- a/internal/usecase/triage/pr_service_test.go
+++ b/internal/usecase/triage/pr_service_test.go
@@ -367,6 +367,14 @@ func (m *MockCommentReader) ListPRComments(ctx context.Context, owner, repo stri
 	return args.Get(0).([]domain.PRFinding), args.Error(1)
 }
 
+func (m *MockCommentReader) ListAllFindings(ctx context.Context, owner, repo string, prNumber int, filterByFingerprint bool) ([]domain.PRFinding, error) {
+	args := m.Called(ctx, owner, repo, prNumber, filterByFingerprint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.PRFinding), args.Error(1)
+}
+
 func (m *MockCommentReader) GetPRComment(ctx context.Context, owner, repo string, prNumber int, commentID int64) (*domain.PRFinding, error) {
 	args := m.Called(ctx, owner, repo, prNumber, commentID)
 	if args.Get(0) == nil {
@@ -615,6 +623,17 @@ func (m *MockCommentWriter) CreateComment(ctx context.Context, owner, repo strin
 	return id, args.Error(1)
 }
 
+// MockIssueCommentWriter implements triage.IssueCommentWriter for testing.
+type MockIssueCommentWriter struct {
+	mock.Mock
+}
+
+func (m *MockIssueCommentWriter) CreateIssueComment(ctx context.Context, owner, repo string, prNumber int, body string) (int64, error) {
+	args := m.Called(ctx, owner, repo, prNumber, body)
+	id, _ := args.Get(0).(int64)
+	return id, args.Error(1)
+}
+
 // MockReviewManager implements triage.ReviewManager for testing.
 type MockReviewManager struct {
 	mock.Mock
@@ -663,14 +682,15 @@ func (m *MockReviewManager) FindThreadForComment(ctx context.Context, owner, rep
 func TestPRService_ReplyToFinding(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("successfully replies to finding by comment ID", func(t *testing.T) {
+	t.Run("successfully replies to in-diff finding by comment ID", func(t *testing.T) {
 		mockComment := new(MockCommentReader)
 		mockWriter := new(MockCommentWriter)
 
 		finding := &domain.PRFinding{
-			CommentID: 12345,
-			Path:      "main.go",
-			Body:      "Test finding",
+			CommentID:   12345,
+			Path:        "main.go",
+			Body:        "Test finding",
+			IsOutOfDiff: false,
 		}
 
 		mockComment.On("GetPRComment", ctx, "owner", "repo", 42, int64(12345)).
@@ -691,12 +711,63 @@ func TestPRService_ReplyToFinding(t *testing.T) {
 		mockWriter.AssertExpectations(t)
 	})
 
-	t.Run("returns ErrNotImplemented when writer is nil", func(t *testing.T) {
-		svc := triage.NewPRService(triage.PRServiceDeps{})
+	t.Run("successfully replies to out-of-diff finding via issue comment", func(t *testing.T) {
+		mockComment := new(MockCommentReader)
+		mockIssueWriter := new(MockIssueCommentWriter)
 
-		_, err := svc.ReplyToFinding(ctx, "owner", "repo", 42, "123", "reply")
+		finding := &domain.PRFinding{
+			CommentID:   67890,
+			Fingerprint: "abc123def456",
+			Path:        "deleted.go",
+			Body:        "Out of diff finding",
+			IsOutOfDiff: true,
+		}
+
+		mockComment.On("GetPRCommentByFingerprint", ctx, "owner", "repo", 42, "abc123def456").
+			Return(finding, nil)
+
+		// The reply should be formatted with CR_REPLY_TO marker
+		expectedBody := "**Re: deleted.go**\n\nAcknowledged, will fix.\n\n<!-- CR_REPLY_TO:abc123def456 -->"
+		mockIssueWriter.On("CreateIssueComment", ctx, "owner", "repo", 42, expectedBody).
+			Return(int64(88888), nil)
+
+		svc := triage.NewPRService(triage.PRServiceDeps{
+			CommentReader:      mockComment,
+			IssueCommentWriter: mockIssueWriter,
+		})
+
+		replyID, err := svc.ReplyToFinding(ctx, "owner", "repo", 42, "CR_FP:abc123def456", "Acknowledged, will fix.")
+		require.NoError(t, err)
+		assert.Equal(t, int64(88888), replyID)
+
+		mockComment.AssertExpectations(t)
+		mockIssueWriter.AssertExpectations(t)
+	})
+
+	t.Run("returns ErrNotImplemented for out-of-diff when IssueCommentWriter is nil", func(t *testing.T) {
+		mockComment := new(MockCommentReader)
+		mockWriter := new(MockCommentWriter)
+
+		finding := &domain.PRFinding{
+			CommentID:   67890,
+			Fingerprint: "abc123",
+			Path:        "deleted.go",
+			IsOutOfDiff: true,
+		}
+
+		mockComment.On("GetPRComment", ctx, "owner", "repo", 42, int64(67890)).
+			Return(finding, nil)
+
+		svc := triage.NewPRService(triage.PRServiceDeps{
+			CommentReader: mockComment,
+			CommentWriter: mockWriter,
+			// IssueCommentWriter is nil
+		})
+
+		_, err := svc.ReplyToFinding(ctx, "owner", "repo", 42, "67890", "reply")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, triage.ErrNotImplemented)
+		assert.Contains(t, err.Error(), "IssueCommentWriter required")
 	})
 
 	t.Run("returns ErrNotImplemented when reader is nil", func(t *testing.T) {
@@ -707,6 +778,28 @@ func TestPRService_ReplyToFinding(t *testing.T) {
 		})
 
 		_, err := svc.ReplyToFinding(ctx, "owner", "repo", 42, "123", "reply")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, triage.ErrNotImplemented)
+	})
+
+	t.Run("returns ErrNotImplemented for in-diff when CommentWriter is nil", func(t *testing.T) {
+		mockComment := new(MockCommentReader)
+
+		finding := &domain.PRFinding{
+			CommentID:   12345,
+			Path:        "main.go",
+			IsOutOfDiff: false,
+		}
+
+		mockComment.On("GetPRComment", ctx, "owner", "repo", 42, int64(12345)).
+			Return(finding, nil)
+
+		svc := triage.NewPRService(triage.PRServiceDeps{
+			CommentReader: mockComment,
+			// CommentWriter is nil
+		})
+
+		_, err := svc.ReplyToFinding(ctx, "owner", "repo", 42, "12345", "reply")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, triage.ErrNotImplemented)
 	})
@@ -931,7 +1024,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 1, Fingerprint: "fp1", Severity: "high", Category: "security"},
 			{CommentID: 2, Fingerprint: "fp2", Severity: "medium", Category: "style"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -943,6 +1036,36 @@ func TestPRService_ListFindings(t *testing.T) {
 		mockComment.AssertExpectations(t)
 	})
 
+	t.Run("returns both in-diff and out-of-diff findings", func(t *testing.T) {
+		mockComment := new(MockCommentReader)
+		findings := []domain.PRFinding{
+			{CommentID: 1, Fingerprint: "fp1", Severity: "high", IsOutOfDiff: false},
+			{CommentID: 2, Fingerprint: "fp2", Severity: "high", IsOutOfDiff: true},
+		}
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
+
+		svc := triage.NewPRService(triage.PRServiceDeps{
+			CommentReader: mockComment,
+		})
+
+		result, err := svc.ListFindings(ctx, "owner", "repo", 42, nil, nil, nil)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+
+		// Verify we get both types
+		var inDiff, outOfDiff int
+		for _, f := range result {
+			if f.IsOutOfDiff {
+				outOfDiff++
+			} else {
+				inDiff++
+			}
+		}
+		assert.Equal(t, 1, inDiff)
+		assert.Equal(t, 1, outOfDiff)
+		mockComment.AssertExpectations(t)
+	})
+
 	t.Run("filters by severity", func(t *testing.T) {
 		mockComment := new(MockCommentReader)
 		findings := []domain.PRFinding{
@@ -950,7 +1073,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 2, Fingerprint: "fp2", Severity: "medium", Category: "style"},
 			{CommentID: 3, Fingerprint: "fp3", Severity: "high", Category: "bug"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -972,7 +1095,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 1, Fingerprint: "fp1", Severity: "high", Category: "security"},
 			{CommentID: 2, Fingerprint: "fp2", Severity: "medium", Category: "style"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -993,7 +1116,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 2, Fingerprint: "fp2", Severity: "high", Category: "style"},
 			{CommentID: 3, Fingerprint: "fp3", Severity: "medium", Category: "security"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -1030,7 +1153,7 @@ func TestPRService_ListFindings(t *testing.T) {
 
 	t.Run("propagates errors from CommentReader", func(t *testing.T) {
 		mockComment := new(MockCommentReader)
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(nil, errors.New("api error"))
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(nil, errors.New("api error"))
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -1047,7 +1170,7 @@ func TestPRService_ListFindings(t *testing.T) {
 		findings := []domain.PRFinding{
 			{CommentID: 1, Fingerprint: "fp1", Severity: "low", Category: "style"},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -1067,7 +1190,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 2, Fingerprint: "fp2", HasReply: false, ReplyCount: 0},
 			{CommentID: 3, Fingerprint: "fp3", HasReply: true, ReplyCount: 1},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -1090,7 +1213,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 2, Fingerprint: "fp2", HasReply: false, ReplyCount: 0},
 			{CommentID: 3, Fingerprint: "fp3", HasReply: true, ReplyCount: 1},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -1110,7 +1233,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 1, Fingerprint: "fp1", HasReply: true},
 			{CommentID: 2, Fingerprint: "fp2", HasReply: false},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,
@@ -1142,7 +1265,7 @@ func TestPRService_ListFindings(t *testing.T) {
 			{CommentID: 3, Fingerprint: "fp3", Severity: "low", HasReply: false},
 			{CommentID: 4, Fingerprint: "fp4", Severity: "low", HasReply: true},
 		}
-		mockComment.On("ListPRComments", ctx, "owner", "repo", 42, true).Return(findings, nil)
+		mockComment.On("ListAllFindings", ctx, "owner", "repo", 42, true).Return(findings, nil)
 
 		svc := triage.NewPRService(triage.PRServiceDeps{
 			CommentReader: mockComment,


### PR DESCRIPTION
## Summary

- Findings on lines not included in the PR diff (deleted lines, unchanged context) were previously embedded in the summary comment's "Findings Outside Diff" section, making them invisible to MCP tools during triage
- This change posts out-of-diff findings as individual GitHub issue comments with fingerprint markers, enabling MCP tools to list, reply to, and track them alongside regular review comments
- Adds `PostOutOfDiffAsComments` config option (default: true) to control this behavior

## Test plan

- [x] All existing tests pass (`mage ci`)
- [x] New tests for issue comment CRUD operations
- [x] New tests for ListAllFindings merging review and issue comments
- [x] New tests for PRService out-of-diff reply handling
- [x] New tests for PostOutOfDiffAsComments config option
- [ ] Manual test: run review generating out-of-diff findings, verify they appear in `list_findings` MCP tool
- [ ] Manual test: reply to out-of-diff finding via MCP, verify reply appears as issue comment