### PR TITLE
fix: wire up out-of-diff findings to post as issue comments

### DIFF
--- a/cmd/bop/main.go
+++ b/cmd/bop/main.go
@@ -231,6 +231,10 @@ func run() error {
 			posterOpts = append(posterOpts, usecasegithub.WithSemanticComparer(semanticComparer, semanticConfig))
 		}
 
+		// Enable posting out-of-diff findings as issue comments (Issue #259)
+		// This makes them visible to MCP triage tools
+		posterOpts = append(posterOpts, usecasegithub.WithIssueCommentClient(githubClient))
+
 		reviewPoster := usecasegithub.NewReviewPoster(githubClient, posterOpts...)
 		githubPoster = &githubPosterAdapter{poster: reviewPoster}
 
@@ -742,16 +746,17 @@ func (a *githubPosterAdapter) PostReview(ctx context.Context, req review.GitHubP
 	// Build the post request with review action configuration
 	// Pass Diff to enable post-deduplication summary generation
 	postReq := usecasegithub.PostReviewRequest{
-		Owner:         req.Owner,
-		Repo:          req.Repo,
-		PullNumber:    req.PRNumber,
-		CommitSHA:     req.CommitSHA,
-		Review:        req.Review, // Use original review; poster will build summary from Diff
-		Findings:      positionedFindings,
-		Diff:          &req.Diff, // Pass diff for post-dedup summary generation
-		ReviewActions: reviewActions,
-		BotUsername:   req.BotUsername,
-		Cost:          req.Cost,
+		Owner:                   req.Owner,
+		Repo:                    req.Repo,
+		PullNumber:              req.PRNumber,
+		CommitSHA:               req.CommitSHA,
+		Review:                  req.Review, // Use original review; poster will build summary from Diff
+		Findings:                positionedFindings,
+		Diff:                    &req.Diff, // Pass diff for post-dedup summary generation
+		ReviewActions:           reviewActions,
+		BotUsername:             req.BotUsername,
+		Cost:                    req.Cost,
+		PostOutOfDiffAsComments: req.PostOutOfDiffAsComments,
 	}
 
 	// Post the review
@@ -770,6 +775,8 @@ func (a *githubPosterAdapter) PostReview(ctx context.Context, req review.GitHubP
 		CurrentCost:               result.CurrentCost,
 		PriorCost:                 result.PriorCost,
 		CumulativeCost:            result.CumulativeCost,
+		OutOfDiffPosted:           result.OutOfDiffPosted,
+		OutOfDiffSkipped:          result.OutOfDiffSkipped,
 	}, nil
 }
 

--- a/internal/adapter/mcp/review_handlers.go
+++ b/internal/adapter/mcp/review_handlers.go
@@ -465,12 +465,13 @@ func (s *Server) handlePostFindings(ctx context.Context, req *mcp.CallToolReques
 
 	// Build post request
 	postReq := review.GitHubPostRequest{
-		Owner:     input.Owner,
-		Repo:      input.Repo,
-		PRNumber:  input.PRNumber,
-		CommitSHA: metadata.HeadSHA,
-		Review:    domainReview,
-		Diff:      diff,
+		Owner:                   input.Owner,
+		Repo:                    input.Repo,
+		PRNumber:                input.PRNumber,
+		CommitSHA:               metadata.HeadSHA,
+		Review:                  domainReview,
+		Diff:                    diff,
+		PostOutOfDiffAsComments: true, // Always post out-of-diff findings as issue comments for MCP visibility
 	}
 
 	// Map review action to GitHub format

--- a/internal/usecase/post/service.go
+++ b/internal/usecase/post/service.go
@@ -112,7 +112,8 @@ func (s *Service) PostFindings(ctx context.Context, req Request) (*Result, error
 		Review: domain.Review{
 			Findings: req.Findings,
 		},
-		Diff: diff,
+		Diff:                    diff,
+		PostOutOfDiffAsComments: true, // Post out-of-diff findings as issue comments for MCP visibility
 	}
 
 	// Apply review action override if specified

--- a/internal/usecase/review/orchestrator.go
+++ b/internal/usecase/review/orchestrator.go
@@ -145,6 +145,12 @@ type GitHubPostRequest struct {
 
 	// Cost is the total cost of this review in USD (for cost tracking in summary).
 	Cost float64
+
+	// PostOutOfDiffAsComments enables posting out-of-diff findings as individual
+	// issue comments rather than only including them in the summary section.
+	// When enabled, these findings appear in the PR conversation and are visible
+	// to MCP triage tools.
+	PostOutOfDiffAsComments bool
 }
 
 // GitHubPostResult contains the result of posting a review.
@@ -160,6 +166,10 @@ type GitHubPostResult struct {
 	CurrentCost    float64
 	PriorCost      float64
 	CumulativeCost float64
+
+	// Out-of-diff tracking
+	OutOfDiffPosted  int
+	OutOfDiffSkipped int
 }
 
 // StorePrecisionPrior represents precision tracking for a provider/category combination.
@@ -308,6 +318,12 @@ type BranchRequest struct {
 	// Set to empty string to disable auto-dismiss (use "none" in config).
 	// Default: "github-actions[bot]"
 	BotUsername string
+
+	// PostOutOfDiffAsComments enables posting out-of-diff findings as individual
+	// issue comments rather than only including them in the summary section.
+	// When enabled, these findings appear in the PR conversation and are visible
+	// to MCP triage tools.
+	PostOutOfDiffAsComments bool
 
 	// SkipVerification disables agent-based verification of findings.
 	// When true, findings from LLM providers are reported directly without verification.
@@ -956,21 +972,22 @@ func (o *Orchestrator) ReviewBranch(ctx context.Context, req BranchRequest) (Res
 	var githubResult *GitHubPostResult
 	if req.PostToGitHub && o.deps.GitHubPoster != nil {
 		result, err := o.deps.GitHubPoster.PostReview(ctx, GitHubPostRequest{
-			Owner:                 req.GitHubOwner,
-			Repo:                  req.GitHubRepo,
-			PRNumber:              req.PRNumber,
-			CommitSHA:             req.CommitSHA,
-			Review:                mergedReview,
-			Diff:                  diff,
-			ActionOnCritical:      req.ActionOnCritical,
-			ActionOnHigh:          req.ActionOnHigh,
-			ActionOnMedium:        req.ActionOnMedium,
-			ActionOnLow:           req.ActionOnLow,
-			ActionOnClean:         req.ActionOnClean,
-			ActionOnNonBlocking:   req.ActionOnNonBlocking,
-			AlwaysBlockCategories: req.AlwaysBlockCategories,
-			BotUsername:           req.BotUsername,
-			Cost:                  mergedReview.Cost,
+			Owner:                   req.GitHubOwner,
+			Repo:                    req.GitHubRepo,
+			PRNumber:                req.PRNumber,
+			CommitSHA:               req.CommitSHA,
+			Review:                  mergedReview,
+			Diff:                    diff,
+			ActionOnCritical:        req.ActionOnCritical,
+			ActionOnHigh:            req.ActionOnHigh,
+			ActionOnMedium:          req.ActionOnMedium,
+			ActionOnLow:             req.ActionOnLow,
+			ActionOnClean:           req.ActionOnClean,
+			ActionOnNonBlocking:     req.ActionOnNonBlocking,
+			AlwaysBlockCategories:   req.AlwaysBlockCategories,
+			BotUsername:             req.BotUsername,
+			Cost:                    mergedReview.Cost,
+			PostOutOfDiffAsComments: req.PostOutOfDiffAsComments,
 		})
 		if err != nil {
 			// Log warning but don't fail the review
@@ -1426,21 +1443,22 @@ func (o *Orchestrator) ReviewBranchWithDiff(ctx context.Context, req BranchReque
 	var githubResult *GitHubPostResult
 	if req.PostToGitHub && o.deps.GitHubPoster != nil {
 		result, err := o.deps.GitHubPoster.PostReview(ctx, GitHubPostRequest{
-			Owner:                 req.GitHubOwner,
-			Repo:                  req.GitHubRepo,
-			PRNumber:              req.PRNumber,
-			CommitSHA:             req.CommitSHA,
-			Review:                mergedReview,
-			Diff:                  diff,
-			ActionOnCritical:      req.ActionOnCritical,
-			ActionOnHigh:          req.ActionOnHigh,
-			ActionOnMedium:        req.ActionOnMedium,
-			ActionOnLow:           req.ActionOnLow,
-			ActionOnClean:         req.ActionOnClean,
-			ActionOnNonBlocking:   req.ActionOnNonBlocking,
-			AlwaysBlockCategories: req.AlwaysBlockCategories,
-			BotUsername:           req.BotUsername,
-			Cost:                  mergedReview.Cost,
+			Owner:                   req.GitHubOwner,
+			Repo:                    req.GitHubRepo,
+			PRNumber:                req.PRNumber,
+			CommitSHA:               req.CommitSHA,
+			Review:                  mergedReview,
+			Diff:                    diff,
+			ActionOnCritical:        req.ActionOnCritical,
+			ActionOnHigh:            req.ActionOnHigh,
+			ActionOnMedium:          req.ActionOnMedium,
+			ActionOnLow:             req.ActionOnLow,
+			ActionOnClean:           req.ActionOnClean,
+			ActionOnNonBlocking:     req.ActionOnNonBlocking,
+			AlwaysBlockCategories:   req.AlwaysBlockCategories,
+			BotUsername:             req.BotUsername,
+			Cost:                    mergedReview.Cost,
+			PostOutOfDiffAsComments: req.PostOutOfDiffAsComments,
 		})
 		if err != nil {
 			if o.deps.Logger != nil {

--- a/internal/usecase/review/pr_review.go
+++ b/internal/usecase/review/pr_review.go
@@ -46,14 +46,15 @@ type PRRequest struct {
 	PostToGitHub bool // Enable posting review to GitHub PR
 
 	// Review action configuration (only used if PostToGitHub is true)
-	ActionOnCritical      string
-	ActionOnHigh          string
-	ActionOnMedium        string
-	ActionOnLow           string
-	ActionOnClean         string
-	ActionOnNonBlocking   string
-	AlwaysBlockCategories []string
-	BotUsername           string
+	ActionOnCritical        string
+	ActionOnHigh            string
+	ActionOnMedium          string
+	ActionOnLow             string
+	ActionOnClean           string
+	ActionOnNonBlocking     string
+	AlwaysBlockCategories   []string
+	BotUsername             string
+	PostOutOfDiffAsComments bool
 
 	// Verification settings
 	SkipVerification   bool
@@ -154,32 +155,33 @@ func (o *Orchestrator) prToBranchRequest(req PRRequest, metadata *domain.PRMetad
 	}
 
 	return BranchRequest{
-		BaseRef:               metadata.BaseRef,
-		TargetRef:             metadata.HeadRef,
-		OutputDir:             req.OutputDir,
-		Repository:            repository,
-		IncludeUncommitted:    false, // Remote PRs don't have uncommitted changes
-		CustomInstructions:    req.CustomInstructions,
-		ContextFiles:          req.ContextFiles,
-		NoArchitecture:        true, // We already gathered context remotely
-		NoAutoContext:         true, // We already gathered context remotely
-		Interactive:           false,
-		PostToGitHub:          req.PostToGitHub,
-		GitHubOwner:           req.Owner,
-		GitHubRepo:            req.Repo,
-		PRNumber:              req.PRNumber,
-		CommitSHA:             metadata.HeadSHA,
-		ActionOnCritical:      req.ActionOnCritical,
-		ActionOnHigh:          req.ActionOnHigh,
-		ActionOnMedium:        req.ActionOnMedium,
-		ActionOnLow:           req.ActionOnLow,
-		ActionOnClean:         req.ActionOnClean,
-		ActionOnNonBlocking:   req.ActionOnNonBlocking,
-		AlwaysBlockCategories: req.AlwaysBlockCategories,
-		BotUsername:           req.BotUsername,
-		SkipVerification:      req.SkipVerification,
-		VerificationConfig:    req.VerificationConfig,
-		Reviewers:             req.Reviewers,
+		BaseRef:                 metadata.BaseRef,
+		TargetRef:               metadata.HeadRef,
+		OutputDir:               req.OutputDir,
+		Repository:              repository,
+		IncludeUncommitted:      false, // Remote PRs don't have uncommitted changes
+		CustomInstructions:      req.CustomInstructions,
+		ContextFiles:            req.ContextFiles,
+		NoArchitecture:          true, // We already gathered context remotely
+		NoAutoContext:           true, // We already gathered context remotely
+		Interactive:             false,
+		PostToGitHub:            req.PostToGitHub,
+		GitHubOwner:             req.Owner,
+		GitHubRepo:              req.Repo,
+		PRNumber:                req.PRNumber,
+		CommitSHA:               metadata.HeadSHA,
+		ActionOnCritical:        req.ActionOnCritical,
+		ActionOnHigh:            req.ActionOnHigh,
+		ActionOnMedium:          req.ActionOnMedium,
+		ActionOnLow:             req.ActionOnLow,
+		ActionOnClean:           req.ActionOnClean,
+		ActionOnNonBlocking:     req.ActionOnNonBlocking,
+		AlwaysBlockCategories:   req.AlwaysBlockCategories,
+		BotUsername:             req.BotUsername,
+		PostOutOfDiffAsComments: req.PostOutOfDiffAsComments,
+		SkipVerification:        req.SkipVerification,
+		VerificationConfig:      req.VerificationConfig,
+		Reviewers:               req.Reviewers,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wire up `WithIssueCommentClient` option that was added in v0.8.1 but never connected to the CLI
- Add `PostOutOfDiffAsComments` field throughout the request chain to enable the feature
- Enable out-of-diff issue comments by default in MCP handlers for triage tool visibility

## Test plan
- [x] `mage build` passes
- [x] `mage test` passes  
- [x] `mage lint` passes
- [ ] Manual test: Review a PR with out-of-diff findings and verify they appear as individual issue comments
- [ ] Manual test: Verify MCP `list_findings` tool returns out-of-diff findings