### PR TITLE
feat(config): implement multi-file config merging

### DIFF
--- a/cmd/bop/main.go
+++ b/cmd/bop/main.go
@@ -358,11 +358,11 @@ func repositoryName(repoDir string) string {
 }
 
 func defaultConfigPaths() []string {
-	paths := []string{"."}
-	if home, err := os.UserHomeDir(); err == nil {
-		paths = append(paths, filepath.Join(home, ".config", "bop"))
-	}
-	return paths
+	// The config loader now handles standard paths internally:
+	// 1. ~/.config/bop/ (user config, base)
+	// 2. Current directory (project config, overlay)
+	// This function is for custom override paths only.
+	return nil
 }
 
 // parseLogLevelFlag scans os.Args for --log-level flag before Cobra processes commands.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -18,38 +18,45 @@ type LoaderOptions struct {
 }
 
 // Load returns the merged configuration from files and environment variables.
+// Config files are loaded in order: user config (~/.config/bop/) first as base,
+// then project config (current directory) overlays it. Environment variables
+// override both.
 func Load(opts LoaderOptions) (Config, error) {
-	v := viper.New()
-
 	name := opts.FileName
 	if name == "" {
 		name = "bop"
-	}
-
-	configFile := locateConfigFile(name, opts.ConfigPaths)
-	if configFile != "" {
-		v.SetConfigFile(configFile)
-	} else {
-		v.SetConfigName(name)
 	}
 
 	prefix := opts.EnvPrefix
 	if prefix == "" {
 		prefix = "BOP"
 	}
+
+	// Create master viper instance with defaults and env var handling
+	v := viper.New()
 	v.SetEnvPrefix(prefix)
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	v.AllowEmptyEnv(true)
-
 	setDefaults(v)
 
-	if configFile != "" {
-		if err := v.ReadInConfig(); err != nil {
+	// Find all config files in priority order (base → overlay)
+	configFiles := locateConfigFiles(name, opts.ConfigPaths)
+
+	// Read and merge each config file (later files override earlier)
+	for _, configFile := range configFiles {
+		fileViper := viper.New()
+		fileViper.SetConfigFile(configFile)
+		if err := fileViper.ReadInConfig(); err != nil {
 			return Config{}, fmt.Errorf("read config %s: %w", configFile, err)
+		}
+		// Merge this file's settings into master viper
+		if err := v.MergeConfigMap(fileViper.AllSettings()); err != nil {
+			return Config{}, fmt.Errorf("merge config %s: %w", configFile, err)
 		}
 	}
 
+	// Unmarshal merged config
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return Config{}, fmt.Errorf("unmarshal config: %w", err)
@@ -237,20 +244,50 @@ func expandEnvStringSlice(slice []string) []string {
 	return result
 }
 
-func locateConfigFile(name string, paths []string) string {
-	searchPaths := append([]string{}, paths...)
+// locateConfigFiles returns all matching config files in load order (base → overlay).
+// User config (~/.config/bop/) is loaded first as base, then paths in order,
+// finally current directory. Later files override earlier ones during merge.
+func locateConfigFiles(name string, paths []string) []string {
+	var files []string
+	seen := make(map[string]bool)
+
+	// Build search paths in priority order (lowest first, loaded first)
+	searchPaths := make([]string, 0, len(paths)+2)
+
+	// 1. User config directory (lowest priority, loaded first as base)
+	if home, err := os.UserHomeDir(); err == nil {
+		searchPaths = append(searchPaths, filepath.Join(home, ".config", "bop"))
+	}
+
+	// 2. Explicit paths from caller
+	searchPaths = append(searchPaths, paths...)
+
+	// 3. Current directory (highest priority, loaded last as overlay)
 	searchPaths = append(searchPaths, ".")
+
 	for _, dir := range searchPaths {
 		if dir == "" {
 			continue
 		}
 		candidate := filepath.Join(dir, name+".yaml")
+
+		// Normalize path to avoid duplicates from "." resolution
+		absCandidate, err := filepath.Abs(candidate)
+		if err != nil {
+			absCandidate = candidate
+		}
+
+		if seen[absCandidate] {
+			continue
+		}
+
 		info, err := os.Stat(candidate)
 		if err == nil && !info.IsDir() {
-			return candidate
+			files = append(files, candidate)
+			seen[absCandidate] = true
 		}
 	}
-	return ""
+	return files
 }
 
 func setDefaults(v *viper.Viper) {


### PR DESCRIPTION
## Summary

Implement config merging so user config (`~/.config/bop/bop.yaml`) is not shadowed by project config (`./bop.yaml`).

## Problem

Previously, bop used first-match semantics for config loading. When running in a directory with `./bop.yaml`, the user's personal config at `~/.config/bop/bop.yaml` was completely ignored. This made it impossible to have personal auth settings that work across different projects.

## Solution

- Refactor `locateConfigFile()` → `locateConfigFiles()` to find all matching configs
- Load configs in priority order: user config first (base), project config second (overlay)
- Use `viper.MergeConfigMap()` to combine settings
- Later configs override earlier ones, so project-specific settings take precedence

## Resulting behavior

| Config Location | Contains | Loaded As |
|-----------------|----------|-----------|
| `~/.config/bop/bop.yaml` | User auth, personal prefs | Base |
| `./bop.yaml` | Project reviewers, providers | Overlay |
| `BOP_*` env vars | Runtime overrides | Final |

## Test plan

- [x] Verified auth commands appear when user config has auth settings
- [x] Verified project reviewers still load from project config
- [x] End-to-end test: `bop auth login` works with user config + project config