### PR TITLE
feat(feedback): Add feedback client and commands for platform feedback-service

### DIFF
--- a/cmd/bop-mcp/main.go
+++ b/cmd/bop-mcp/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/delightfulhammers/bop/internal/adapter/analytics"
+	"github.com/delightfulhammers/bop/internal/adapter/feedback"
 	"github.com/delightfulhammers/bop/internal/adapter/git"
 	"github.com/delightfulhammers/bop/internal/adapter/github"
 	"github.com/delightfulhammers/bop/internal/adapter/llm/provider"
@@ -142,6 +143,16 @@ func run() error {
 		}
 	}
 
+	// Create feedback client if platform mode is enabled (Week 15)
+	var feedbackClient *feedback.Client
+	if platformMode && tokenStore != nil && cfg.Auth.ServiceURL != "" {
+		feedbackClient = feedback.NewClient(
+			cfg.Auth.ServiceURL,
+			tokenStore,
+			feedback.WithVersion(version.Value()),
+		)
+	}
+
 	// Create provider factory - builds direct providers from environment variables
 	// and supports sampling fallback for zero-config usage.
 	providerFactory := provider.NewFactory(provider.FactoryOptions{
@@ -197,8 +208,9 @@ func run() error {
 		AuthClient:   authClient,
 		TokenStore:   tokenStore,
 		PlatformMode: platformMode,
-		// Week 15: Analytics
-		Analytics: analyticsEmitter,
+		// Week 15: Analytics and Feedback
+		Analytics:      analyticsEmitter,
+		FeedbackClient: feedbackClient,
 	})
 
 	// Run the server (blocks until context is cancelled or error occurs).

--- a/cmd/bop/main.go
+++ b/cmd/bop/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/delightfulhammers/bop/internal/adapter/analytics"
 	"github.com/delightfulhammers/bop/internal/adapter/cli"
 	dedupadapter "github.com/delightfulhammers/bop/internal/adapter/dedup"
+	"github.com/delightfulhammers/bop/internal/adapter/feedback"
 	"github.com/delightfulhammers/bop/internal/adapter/git"
 	githubadapter "github.com/delightfulhammers/bop/internal/adapter/github"
 	"github.com/delightfulhammers/bop/internal/adapter/llm/anthropic"
@@ -316,12 +317,16 @@ func run() error {
 	// Initialize auth components for platform authentication (Week 14)
 	authDeps := buildAuthDependencies(cfg.Auth)
 
+	// Initialize feedback client for platform feedback (Week 15)
+	feedbackClient := buildFeedbackClient(cfg.Auth, authDeps, version.Value())
+
 	root := cli.NewRootCommand(cli.Dependencies{
 		BranchReviewer:      orchestrator,
 		PRReviewer:          orchestrator, // Phase 3.5: Remote PR review
 		FindingsPoster:      findingsPoster,
 		SessionManager:      sessionManager,
-		AuthDeps:            authDeps, // Week 14: Platform authentication
+		AuthDeps:            authDeps,       // Week 14: Platform authentication
+		FeedbackClient:      feedbackClient, // Week 15: Feedback
 		DefaultOutput:       cfg.Output.Directory,
 		DefaultRepo:         repoName,
 		DefaultInstructions: cfg.Review.Instructions,
@@ -503,6 +508,29 @@ func buildAuthDependencies(cfg config.AuthConfig) cli.AuthDependencies {
 		TokenStore:   tokenStore,
 		PlatformMode: true,
 	}
+}
+
+// buildFeedbackClient creates a feedback client based on auth configuration.
+// Returns nil if auth mode is "legacy" or auth dependencies are not fully configured.
+// This requires platform auth to be enabled since feedback requires authentication.
+func buildFeedbackClient(cfg config.AuthConfig, authDeps cli.AuthDependencies, version string) cli.FeedbackClient {
+	// Feedback requires platform auth mode
+	if !authDeps.PlatformMode || authDeps.TokenStore == nil {
+		return nil
+	}
+
+	// Feedback service URL defaults to auth service URL (same platform)
+	serviceURL := cfg.ServiceURL
+	if serviceURL == "" {
+		return nil
+	}
+
+	// Create the feedback client
+	return feedback.NewClient(
+		serviceURL,
+		authDeps.TokenStore,
+		feedback.WithVersion(version),
+	)
 }
 
 // buildObservability creates observability components based on configuration

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 replace github.com/delightfulhammers/platform => ../platform
 
 require (
-	github.com/delightfulhammers/platform v0.0.0
+	github.com/delightfulhammers/platform v0.0.0-00010101000000-000000000000
 	github.com/go-git/go-git/v5 v5.16.3
 	github.com/google/uuid v1.6.0
 	github.com/magefile/mage v1.15.0

--- a/internal/adapter/cli/feedback.go
+++ b/internal/adapter/cli/feedback.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/delightfulhammers/bop/internal/adapter/feedback"
+	platformfeedback "github.com/delightfulhammers/platform/contracts/feedback"
+)
+
+// FeedbackClient defines the interface for feedback operations.
+type FeedbackClient interface {
+	Submit(ctx context.Context, req feedback.SubmitRequest) (*feedback.SubmitResponse, error)
+	List(ctx context.Context) (*feedback.ListResponse, error)
+	Get(ctx context.Context, id uuid.UUID) (*platformfeedback.Feedback, error)
+}
+
+// NewFeedbackCommand creates the feedback command group.
+func NewFeedbackCommand(client FeedbackClient, authDeps AuthDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "feedback",
+		Short: "Submit and view product feedback",
+		Long: `Submit feedback about bop to help us improve.
+
+Use 'bop feedback submit' to submit new feedback.
+Use 'bop feedback list' to view your submitted feedback.
+Use 'bop feedback show <id>' to view a specific feedback item.`,
+	}
+
+	cmd.AddCommand(newFeedbackSubmitCommand(client, authDeps))
+	cmd.AddCommand(newFeedbackListCommand(client, authDeps))
+	cmd.AddCommand(newFeedbackShowCommand(client, authDeps))
+
+	return cmd
+}
+
+func newFeedbackSubmitCommand(client FeedbackClient, authDeps AuthDependencies) *cobra.Command {
+	var category string
+	var title string
+	var description string
+
+	cmd := &cobra.Command{
+		Use:   "submit",
+		Short: "Submit new feedback",
+		Long: `Submit feedback about bop to help us improve.
+
+Categories:
+  bug        - Report a bug or issue
+  feature    - Request a new feature
+  usability  - Report usability issues
+  other      - General feedback
+
+Example:
+  bop feedback submit --category bug --title "Review fails on large files" --description "When reviewing files over 10MB..."`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Require auth in platform mode
+			if _, err := authDeps.RequireAuth(); err != nil {
+				return err
+			}
+
+			// Validate category
+			cat := platformfeedback.Category(strings.ToUpper(category))
+			if !cat.IsValid() {
+				return fmt.Errorf("invalid category %q - must be one of: bug, feature, usability, other", category)
+			}
+
+			// Validate required fields
+			if title == "" {
+				return fmt.Errorf("--title is required")
+			}
+			if description == "" {
+				return fmt.Errorf("--description is required")
+			}
+
+			resp, err := client.Submit(cmd.Context(), feedback.SubmitRequest{
+				Category:    cat,
+				Title:       title,
+				Description: description,
+				ClientType:  platformfeedback.ClientTypeCLI,
+			})
+			if err != nil {
+				return fmt.Errorf("submit feedback: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Feedback submitted successfully!\n")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  ID: %s\n", resp.ID)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Status: %s\n", resp.Status)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nThank you for your feedback!\n")
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&category, "category", "c", "", "Feedback category: bug, feature, usability, other (required)")
+	cmd.Flags().StringVarP(&title, "title", "t", "", "Brief summary of the feedback (required)")
+	cmd.Flags().StringVarP(&description, "description", "d", "", "Detailed description of the feedback (required)")
+	_ = cmd.MarkFlagRequired("category")
+	_ = cmd.MarkFlagRequired("title")
+	_ = cmd.MarkFlagRequired("description")
+
+	return cmd
+}
+
+func newFeedbackListCommand(client FeedbackClient, authDeps AuthDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List your submitted feedback",
+		Long:  `View all feedback you have submitted.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Require auth in platform mode
+			if _, err := authDeps.RequireAuth(); err != nil {
+				return err
+			}
+
+			resp, err := client.List(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("list feedback: %w", err)
+			}
+
+			if len(resp.Feedback) == 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No feedback submitted yet.")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nUse 'bop feedback submit' to submit your first feedback.")
+				return nil
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Your feedback (%d total):\n\n", resp.Total)
+
+			for _, f := range resp.Feedback {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", f.ID)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Category: %s\n", f.Category)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Title:    %s\n", f.Title)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Status:   %s\n", f.Status)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    Created:  %s\n\n", f.CreatedAt.Format("2006-01-02 15:04"))
+			}
+
+			if resp.HasMore {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "(More feedback available)")
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newFeedbackShowCommand(client FeedbackClient, authDeps AuthDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <id>",
+		Short: "Show details of a specific feedback item",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Require auth in platform mode
+			if _, err := authDeps.RequireAuth(); err != nil {
+				return err
+			}
+
+			id, err := uuid.Parse(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid feedback ID: %w", err)
+			}
+
+			f, err := client.Get(cmd.Context(), id)
+			if err != nil {
+				return fmt.Errorf("get feedback: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Feedback: %s\n\n", f.ID)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Category:    %s\n", f.Category)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Title:       %s\n", f.Title)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Status:      %s\n", f.Status)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Created:     %s\n", f.CreatedAt.Format("2006-01-02 15:04:05"))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Updated:     %s\n", f.UpdatedAt.Format("2006-01-02 15:04:05"))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nDescription:\n%s\n", f.Description)
+
+			if f.AdminNotes != "" {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nAdmin Notes:\n%s\n", f.AdminNotes)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/adapter/cli/root.go
+++ b/internal/adapter/cli/root.go
@@ -72,6 +72,7 @@ type Dependencies struct {
 	FindingsPoster       FindingsPoster   // Optional: only required for cr post
 	SessionManager       SessionManager   // Optional: only required for cr sessions
 	AuthDeps             AuthDependencies // Optional: only required for bop auth commands
+	FeedbackClient       FeedbackClient   // Optional: only required for bop feedback commands
 	Args                 Arguments
 	DefaultOutput        string
 	DefaultRepo          string
@@ -127,6 +128,10 @@ func NewRootCommand(deps Dependencies) *cobra.Command {
 	// Add auth commands if auth is configured (platform mode)
 	if deps.AuthDeps.TokenStore != nil {
 		root.AddCommand(NewAuthCommand(deps.AuthDeps))
+	}
+	// Add feedback commands if feedback client is configured
+	if deps.FeedbackClient != nil {
+		root.AddCommand(NewFeedbackCommand(deps.FeedbackClient, deps.AuthDeps))
 	}
 
 	var showVersion bool

--- a/internal/adapter/feedback/client.go
+++ b/internal/adapter/feedback/client.go
@@ -1,0 +1,248 @@
+// Package feedback provides an HTTP client for the platform feedback-service.
+package feedback
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/delightfulhammers/bop/internal/auth"
+	"github.com/delightfulhammers/platform/contracts/feedback"
+)
+
+// ProductID is the product identifier for bop feedback.
+const ProductID = "bop"
+
+// Client is an HTTP client for the feedback-service.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	tokenStore *auth.TokenStore
+	version    string
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = client
+	}
+}
+
+// WithVersion sets the client version for context.
+func WithVersion(version string) ClientOption {
+	return func(c *Client) {
+		c.version = version
+	}
+}
+
+// NewClient creates a new feedback client.
+func NewClient(baseURL string, tokenStore *auth.TokenStore, opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL:    baseURL,
+		tokenStore: tokenStore,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// SubmitRequest contains the data needed to submit feedback.
+type SubmitRequest struct {
+	Category    feedback.Category
+	Title       string
+	Description string
+	ClientType  feedback.ClientType
+}
+
+// SubmitResponse is the response from submitting feedback.
+type SubmitResponse struct {
+	ID      uuid.UUID       `json:"id"`
+	Status  feedback.Status `json:"status"`
+	Message string          `json:"message"`
+}
+
+// Submit sends feedback to the feedback-service.
+func (c *Client) Submit(ctx context.Context, req SubmitRequest) (*SubmitResponse, error) {
+	stored, err := c.tokenStore.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load auth: %w", err)
+	}
+
+	if stored.IsExpired() {
+		return nil, fmt.Errorf("authentication expired - run 'bop auth login' to re-authenticate")
+	}
+
+	// Build the request body
+	body := feedback.SubmitFeedbackRequest{
+		ProductID:     ProductID,
+		Category:      req.Category,
+		Title:         req.Title,
+		Description:   req.Description,
+		ClientType:    req.ClientType,
+		ClientVersion: c.version,
+		Context: &feedback.Context{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/feedback", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+stored.AccessToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
+			return nil, fmt.Errorf("submit feedback failed: %s", errResp.Message)
+		}
+		return nil, fmt.Errorf("submit feedback failed: HTTP %d", resp.StatusCode)
+	}
+
+	var result SubmitResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListResponse is the response from listing feedback.
+type ListResponse struct {
+	Feedback []*feedback.Feedback `json:"feedback"`
+	Total    int                  `json:"total"`
+	HasMore  bool                 `json:"has_more"`
+}
+
+// List retrieves the user's own feedback.
+func (c *Client) List(ctx context.Context) (*ListResponse, error) {
+	stored, err := c.tokenStore.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load auth: %w", err)
+	}
+
+	if stored.IsExpired() {
+		return nil, fmt.Errorf("authentication expired - run 'bop auth login' to re-authenticate")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/feedback", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+stored.AccessToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
+			return nil, fmt.Errorf("list feedback failed: %s", errResp.Message)
+		}
+		return nil, fmt.Errorf("list feedback failed: HTTP %d", resp.StatusCode)
+	}
+
+	var result ListResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// Get retrieves a specific feedback item by ID.
+func (c *Client) Get(ctx context.Context, id uuid.UUID) (*feedback.Feedback, error) {
+	stored, err := c.tokenStore.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load auth: %w", err)
+	}
+
+	if stored.IsExpired() {
+		return nil, fmt.Errorf("authentication expired - run 'bop auth login' to re-authenticate")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/feedback/"+id.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+stored.AccessToken)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("feedback not found")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp errorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Message != "" {
+			return nil, fmt.Errorf("get feedback failed: %s", errResp.Message)
+		}
+		return nil, fmt.Errorf("get feedback failed: HTTP %d", resp.StatusCode)
+	}
+
+	var result feedback.Feedback
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// errorResponse represents an API error response.
+type errorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/internal/adapter/mcp/feedback_handlers.go
+++ b/internal/adapter/mcp/feedback_handlers.go
@@ -1,0 +1,127 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/delightfulhammers/bop/internal/adapter/feedback"
+	platformfeedback "github.com/delightfulhammers/platform/contracts/feedback"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// FeedbackClient defines the interface for submitting feedback.
+type FeedbackClient interface {
+	Submit(ctx context.Context, req feedback.SubmitRequest) (*feedback.SubmitResponse, error)
+}
+
+// SubmitFeedbackInput is the input for the submit_feedback tool.
+type SubmitFeedbackInput struct {
+	Category    string `json:"category" jsonschema:"Feedback category: bug, feature, usability, other"`
+	Title       string `json:"title" jsonschema:"Brief summary of the feedback"`
+	Description string `json:"description" jsonschema:"Detailed description of the feedback"`
+}
+
+// SubmitFeedbackOutput is the output for the submit_feedback tool.
+type SubmitFeedbackOutput struct {
+	Success bool   `json:"success"`
+	ID      string `json:"id,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Message string `json:"message"`
+}
+
+// registerSubmitFeedbackTool registers the submit_feedback tool.
+func (s *Server) registerSubmitFeedbackTool() {
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "submit_feedback",
+		Description: `Submit feedback about bop to help us improve.
+
+Categories:
+- bug: Report a bug or issue
+- feature: Request a new feature
+- usability: Report usability issues
+- other: General feedback
+
+Requires authentication (bop auth login).`,
+	}, s.handleSubmitFeedback)
+}
+
+func (s *Server) handleSubmitFeedback(ctx context.Context, req *mcp.CallToolRequest, input SubmitFeedbackInput) (*mcp.CallToolResult, SubmitFeedbackOutput, error) {
+	// Check if feedback client is available
+	if s.deps.FeedbackClient == nil {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Feedback service not configured"},
+			},
+		}, SubmitFeedbackOutput{}, nil
+	}
+
+	// Require authentication
+	if err := s.RequireAuth(); err != nil {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: err.Error()},
+			},
+		}, SubmitFeedbackOutput{}, nil
+	}
+
+	// Validate category
+	category := platformfeedback.Category(strings.ToUpper(input.Category))
+	if !category.IsValid() {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Invalid category %q - must be one of: bug, feature, usability, other", input.Category)},
+			},
+		}, SubmitFeedbackOutput{}, nil
+	}
+
+	// Validate required fields
+	if input.Title == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Title is required"},
+			},
+		}, SubmitFeedbackOutput{}, nil
+	}
+	if input.Description == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Description is required"},
+			},
+		}, SubmitFeedbackOutput{}, nil
+	}
+
+	// Submit feedback
+	resp, err := s.deps.FeedbackClient.Submit(ctx, feedback.SubmitRequest{
+		Category:    category,
+		Title:       input.Title,
+		Description: input.Description,
+		ClientType:  platformfeedback.ClientTypeMCP,
+	})
+	if err != nil {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Failed to submit feedback: %v", err)},
+			},
+		}, SubmitFeedbackOutput{}, nil
+	}
+
+	output := SubmitFeedbackOutput{
+		Success: true,
+		ID:      resp.ID.String(),
+		Status:  string(resp.Status),
+		Message: "Feedback submitted successfully. Thank you!",
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: output.Message},
+		},
+	}, output, nil
+}

--- a/internal/adapter/mcp/server.go
+++ b/internal/adapter/mcp/server.go
@@ -134,6 +134,12 @@ type ServerDeps struct {
 	// Analytics emits usage telemetry for product analytics.
 	// Optional: when nil, no analytics are emitted.
 	Analytics review.AnalyticsEmitter
+
+	// === Feedback (Week 15) ===
+
+	// FeedbackClient submits user feedback to the platform.
+	// Optional: when nil, submit_feedback tool is not available.
+	FeedbackClient FeedbackClient
 }
 
 // Server wraps the MCP server and provides triage tools.
@@ -337,6 +343,11 @@ func (s *Server) registerTools() {
 	s.registerPostFindingsTool()
 	s.registerReviewBranchTool()
 	s.registerReviewFilesTool()
+
+	// Week 15: Feedback tool
+	if s.deps.FeedbackClient != nil {
+		s.registerSubmitFeedbackTool()
+	}
 }
 
 // Tool input/output types for M2 PR-based tools.


### PR DESCRIPTION
## Summary
- Add HTTP client for platform feedback-service (`internal/adapter/feedback/client.go`)
- Add CLI commands: `bop feedback submit`, `bop feedback list`, `bop feedback show <id>`
- Add MCP tool: `submit_feedback` for AI-assisted feedback submission

## Details
This PR adds the client-side support for the platform feedback-service (platform PR #141). Users can now submit product feedback directly from the CLI or through MCP tools.

### CLI Usage
```bash
# Submit feedback
bop feedback submit --category bug --title "Review fails on large files" --description "When reviewing files over 10MB..."

# List your feedback
bop feedback list

# Show details of a specific feedback item
bop feedback show <uuid>
```

### MCP Tool
The `submit_feedback` tool allows AI agents to submit feedback on behalf of users.

### Requirements
- Platform authentication required (`bop auth login`)
- Feedback service must be configured and running

## Test plan
- [ ] Verify CLI commands work with mock/real feedback-service
- [ ] Verify MCP tool registers and handles requests correctly
- [ ] Verify authentication is required for all operations
- [ ] Verify error handling for invalid categories, missing fields