### PR TITLE
feat(action): Add GitHub Action with OIDC authentication

### DIFF
--- a/.github/actions/bop-review/action.yml
+++ b/.github/actions/bop-review/action.yml
@@ -8,6 +8,10 @@ inputs:
   tenant-id:
     description: 'Tenant ID for authentication'
     required: true
+  oidc-audience:
+    description: 'OIDC token audience (defaults to hostname from platform-url)'
+    required: false
+    default: ''
   base-ref:
     description: 'Base ref for diff comparison'
     required: false
@@ -36,10 +40,18 @@ runs:
     - name: Get OIDC Token
       id: get-oidc-token
       uses: actions/github-script@v7
+      env:
+        PLATFORM_URL: ${{ inputs.platform-url }}
+        OIDC_AUDIENCE: ${{ inputs.oidc-audience }}
       with:
         script: |
-          // Request OIDC token with platform audience
-          const audience = 'api.delightfulhammers.com';
+          // Derive audience from platform-url if not explicitly set
+          let audience = process.env.OIDC_AUDIENCE;
+          if (!audience) {
+            const url = new URL(process.env.PLATFORM_URL);
+            audience = url.hostname;
+          }
+          core.info(`Requesting OIDC token with audience: ${audience}`);
           const token = await core.getIDToken(audience);
           core.setSecret(token);
           core.setOutput('token', token);
@@ -52,18 +64,36 @@ runs:
         TENANT_ID: ${{ inputs.tenant-id }}
         OIDC_TOKEN: ${{ steps.get-oidc-token.outputs.token }}
       run: |
-        # Exchange GitHub OIDC token for platform access token
-        RESPONSE=$(curl -sf -X POST "${PLATFORM_URL}/auth/actions-oidc" \
-          -H "Content-Type: application/json" \
-          -d "{
-            \"product_id\": \"bop\",
-            \"tenant_id\": \"${TENANT_ID}\",
-            \"provider_type\": \"github\",
-            \"id_token\": \"${OIDC_TOKEN}\"
-          }")
+        # Prevent command echoing to avoid leaking secrets
+        set +x
 
-        if [ $? -ne 0 ]; then
-          echo "::error::Failed to exchange OIDC token for platform credentials"
+        # Build JSON payload safely using jq
+        JSON_PAYLOAD=$(jq -n \
+          --arg tenant_id "${TENANT_ID}" \
+          --arg id_token "${OIDC_TOKEN}" \
+          '{
+            product_id: "bop",
+            tenant_id: $tenant_id,
+            provider_type: "github",
+            id_token: $id_token
+          }')
+
+        # Exchange GitHub OIDC token for platform access token
+        # Use -s (silent) to prevent request details in error output
+        # Use --max-time to prevent hanging on unresponsive server
+        HTTP_CODE=$(curl -s -o response.json -w "%{http_code}" \
+          --max-time 30 \
+          -X POST "${PLATFORM_URL}/auth/actions-oidc" \
+          -H "Content-Type: application/json" \
+          -d "${JSON_PAYLOAD}")
+
+        # Mask response immediately to prevent token leakage
+        RESPONSE=$(cat response.json)
+        echo "::add-mask::${RESPONSE}"
+        rm -f response.json
+
+        if [ "${HTTP_CODE}" != "200" ]; then
+          echo "::error::Failed to exchange OIDC token (HTTP ${HTTP_CODE})"
           exit 1
         fi
 

--- a/docs/examples/bop-review-workflow.yml
+++ b/docs/examples/bop-review-workflow.yml
@@ -1,17 +1,24 @@
-# Example workflow for bop code review using GitHub Actions OIDC
+# =============================================================================
+# EXAMPLE WORKFLOW - Copy to your repository's .github/workflows/ directory
+# =============================================================================
 #
-# This workflow demonstrates how to integrate bop AI code review into your PR workflow
-# using GitHub's OIDC token for secure, keyless authentication.
+# This is a reference example showing how to integrate bop AI code review
+# into your PR workflow using GitHub's OIDC token for secure, keyless auth.
+#
+# This file is located in docs/examples/ and will NOT run automatically.
+# You must copy it to your repository to use it.
 #
 # Prerequisites:
 # 1. Enable OIDC in your GitHub Actions settings
 # 2. Configure your tenant's external_provider_login to match your GitHub org
-# 3. Set up the required secrets/variables in your repository
+# 3. Set up the required repository variables:
+#    - BOP_TENANT_ID: Your tenant's UUID
+#    - BOP_PLATFORM_URL: (optional) Custom platform URL
 #
-# To use this workflow in your own repository:
-# 1. Copy this file to .github/workflows/bop-review.yml
-# 2. Update the tenant-id with your tenant's UUID
-# 3. Update platform-url if using a custom platform deployment
+# To use this workflow:
+# 1. Copy this file to .github/workflows/bop-review.yml in your repository
+# 2. Set BOP_TENANT_ID in your repository variables
+# 3. Commit and push - reviews will run on new PRs
 
 name: bop Code Review
 

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -296,6 +296,14 @@ type OIDCExchangeRequest struct {
 // ExchangeOIDCToken exchanges a GitHub Actions OIDC token for platform credentials.
 // This is used for machine-to-machine authentication from CI/CD pipelines.
 func (c *Client) ExchangeOIDCToken(ctx context.Context, req OIDCExchangeRequest) (*TokenResponse, error) {
+	// Validate required inputs
+	if req.TenantID == "" {
+		return nil, fmt.Errorf("tenant_id is required")
+	}
+	if req.IDToken == "" {
+		return nil, fmt.Errorf("id_token is required")
+	}
+
 	providerType := req.ProviderType
 	if providerType == "" {
 		providerType = "github"


### PR DESCRIPTION
## Summary
- Add `ExchangeOIDCToken` method to auth client for OIDC token exchange
- Create `bop-review` composite GitHub Action for CI/CD integration
- Add example workflow demonstrating how to use the action

## User flow
1. GitHub Action requests OIDC token from GitHub
2. Action exchanges token with platform `/auth/actions-oidc`
3. Platform validates token, provisions user, returns access token
4. Action uses access token for bop review operations

## Usage example
```yaml
- name: Run bop Review
  uses: delightfulhammers/bop/.github/actions/bop-review@main
  with:
    platform-url: 'https://api.delightfulhammers.com'
    tenant-id: '\${{ vars.BOP_TENANT_ID }}'
    base-ref: '\${{ github.base_ref }}'
```

## Dependencies
- Requires platform PR #146 (entitlements resolution for OIDC)

## Test plan
- [x] Build passes (\`go build ./...\`)
- [x] Unit tests pass (\`go test ./internal/auth/...\`)
- [ ] End-to-end test with real GitHub Actions OIDC (after platform deploy)