### PR TITLE
security(auth): default-deny for empty entitlements

### DIFF
--- a/internal/adapter/mcp/server_auth_test.go
+++ b/internal/adapter/mcp/server_auth_test.go
@@ -84,10 +84,11 @@ func TestServer_RequireEntitlement(t *testing.T) {
 			errContains: "private-repos",
 		},
 		{
-			name:        "graceful fallback with empty entitlements",
+			name:        "default-deny with empty entitlements",
 			auth:        authWith([]string{}),
 			entitlement: auth.EntitlementPublicRepos,
-			wantErr:     false, // Empty = all granted (graceful fallback)
+			wantErr:     true, // Empty = no permissions (default-deny)
+			errContains: "public-repos",
 		},
 		{
 			name:        "requires auth first in platform mode",

--- a/internal/auth/entitlements.go
+++ b/internal/auth/entitlements.go
@@ -96,17 +96,11 @@ func (e *BopEntitlements) notifyFallback(entitlement, message string) {
 }
 
 // HasEntitlement checks if the user has a specific entitlement.
-// Graceful fallback: empty entitlements = all permissions granted (platform not enforcing yet).
+// Empty entitlements = no permissions (default-deny).
 func (e *BopEntitlements) HasEntitlement(name string) bool {
 	if e.auth == nil {
 		return false
 	}
-
-	// Graceful fallback: empty entitlements means platform isn't enforcing yet
-	if len(e.auth.Entitlements) == 0 {
-		return true
-	}
-
 	return slices.Contains(e.auth.Entitlements, name)
 }
 

--- a/internal/auth/entitlements_test.go
+++ b/internal/auth/entitlements_test.go
@@ -20,10 +20,10 @@ func TestBopEntitlements_HasEntitlement(t *testing.T) {
 			expected:    false,
 		},
 		{
-			name:        "empty entitlements grants all (graceful fallback)",
+			name:        "empty entitlements denies all (default-deny)",
 			auth:        &StoredAuth{Entitlements: []string{}},
 			entitlement: EntitlementPrivateRepos,
-			expected:    true,
+			expected:    false,
 		},
 		{
 			name:        "has specific entitlement",
@@ -105,11 +105,12 @@ func TestBopEntitlements_CanAccessRepo(t *testing.T) {
 			errMsg:    "organization repositories requires Pro plan",
 		},
 		{
-			name:      "graceful fallback with empty entitlements",
+			name:      "empty entitlements denies private repo (default-deny)",
 			auth:      &StoredAuth{Entitlements: []string{}},
 			isPrivate: true,
 			ownerType: "Organization",
-			wantErr:   false,
+			wantErr:   true,
+			errMsg:    "Private repository access requires Solo plan",
 		},
 	}
 
@@ -181,11 +182,11 @@ func TestBopEntitlements_ResolveModel(t *testing.T) {
 			expectFallback: true,
 		},
 		{
-			name:           "graceful fallback with empty entitlements allows any model",
+			name:           "empty entitlements falls back to default model (default-deny)",
 			auth:           &StoredAuth{Entitlements: []string{}},
 			requested:      "gpt-4",
-			expected:       "gpt-4",
-			expectFallback: false,
+			expected:       DefaultModel,
+			expectFallback: true,
 		},
 	}
 
@@ -330,9 +331,9 @@ func TestBopEntitlements_CanUseLocalConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "graceful fallback with empty entitlements",
+			name:    "empty entitlements denies local config (default-deny)",
 			auth:    &StoredAuth{Entitlements: []string{}},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 
@@ -665,9 +666,9 @@ func TestBopEntitlements_CanReviewPrivateRepos(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "empty entitlements can review private (graceful fallback)",
+			name:     "empty entitlements cannot review private (default-deny)",
 			auth:     &StoredAuth{Entitlements: []string{}},
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "has private-repos entitlement",

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -29,7 +29,7 @@ type StoredAuth struct {
 	TenantID string `json:"tenant_id"`
 
 	// Entitlements are the features the user has access to.
-	// Empty slice means graceful fallback (all permissions granted).
+	// Empty slice means no permissions (default-deny).
 	Entitlements []string `json:"entitlements"`
 
 	// Plan is the user's subscription plan (e.g., "free", "individual", "business").


### PR DESCRIPTION
## Summary
- Remove graceful fallback that granted all permissions when entitlements array was empty
- Empty entitlements now means no permissions (default-deny)
- The platform always populates entitlements, so empty arrays indicate a bug that should fail closed

## Test plan
- [x] All existing entitlement tests updated and passing (39 tests)
- [x] MCP server auth test updated for default-deny behavior
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet` clean, builds successfully

Closes #283