### PR TITLE
feat(auth): add skip handling for actor-based authorization (Phase 3)

### DIFF
--- a/internal/adapter/cli/github_action.go
+++ b/internal/adapter/cli/github_action.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -138,6 +139,14 @@ func runGitHubAction(ctx context.Context, deps GitHubActionDeps) error {
 		if oidcErr != nil {
 			return fmt.Errorf("OIDC authentication: %w", oidcErr)
 		}
+
+		// Handle skip - the platform determined auth succeeded but
+		// the actor doesn't have the right entitlements for this operation.
+		// Write summary, post PR comment if configured, and exit cleanly.
+		if oidcResult.Skip != nil {
+			return handleOIDCSkip(ghCtx, cfg, oidcResult.Skip)
+		}
+
 		if !oidcResult.Entitlements.CanReviewCode() {
 			return errors.New("code review not available on your plan")
 		}
@@ -393,7 +402,8 @@ func writeGitHubOutputs(result review.Result, reviewErr error) error {
 }
 
 // authenticateOIDC performs OIDC authentication for GitHub Actions.
-// Returns the authentication result containing entitlements for access checking.
+// Returns the authentication result containing either entitlements (success) or skip info.
+// When Skip is set, the caller should handle it gracefully (write summary, exit cleanly).
 func authenticateOIDC(ctx context.Context, deps GitHubActionDeps) (*auth.OIDCAuthResult, error) {
 	tenantID := os.Getenv("BOP_TENANT_ID")
 	if tenantID == "" {
@@ -413,6 +423,14 @@ func authenticateOIDC(ctx context.Context, deps GitHubActionDeps) (*auth.OIDCAut
 	result, err := oidc.Authenticate(ctx, tenantID)
 	if err != nil {
 		return nil, err
+	}
+
+	// Handle skip result - the platform determined auth succeeded but
+	// the actor doesn't have the right entitlements for this operation.
+	// Return the skip info to the caller for graceful handling.
+	if result.Skip != nil {
+		fmt.Fprintf(os.Stderr, "::notice::Review skipped: %s\n", result.Skip.UserMessage())
+		return result, nil
 	}
 
 	fmt.Fprintf(os.Stderr, "::notice::Authenticated via OIDC as %s (tenant: %s)\n",
@@ -531,6 +549,142 @@ func truncateUTF8Safe(s string, maxBytes int) string {
 		maxBytes--
 	}
 	return s[:maxBytes]
+}
+
+// handleOIDCSkip handles the case where OIDC authentication succeeded but the
+// actor doesn't have the right entitlements for this operation. It writes a
+// summary, optionally posts a PR comment, and returns nil to exit cleanly.
+func handleOIDCSkip(ghCtx *gitHubContext, cfg actionConfig, skip *auth.SkipInfo) error {
+	// Write skip info to GITHUB_OUTPUT
+	outputFile := os.Getenv("GITHUB_OUTPUT")
+	if outputFile != "" {
+		if err := writeSkipOutput(outputFile, skip); err != nil {
+			fmt.Fprintf(os.Stderr, "::warning::Failed to write skip output: %v\n", err)
+		}
+	}
+
+	// Write skip summary to GITHUB_STEP_SUMMARY
+	summaryFile := os.Getenv("GITHUB_STEP_SUMMARY")
+	if summaryFile != "" {
+		if err := writeSkipSummary(summaryFile, skip); err != nil {
+			fmt.Fprintf(os.Stderr, "::warning::Failed to write skip summary: %v\n", err)
+		}
+	}
+
+	// Post PR comment if configured and we have the necessary context
+	if cfg.PostFindings && ghCtx != nil && ghCtx.PRNumber > 0 {
+		if err := postSkipComment(ghCtx, skip); err != nil {
+			fmt.Fprintf(os.Stderr, "::warning::Failed to post skip comment: %v\n", err)
+		}
+	}
+
+	// Log the skip for visibility
+	fmt.Printf("::notice::bop review skipped: %s\n", skip.UserMessage())
+
+	// Return nil to exit cleanly (don't fail the workflow)
+	return nil
+}
+
+// writeSkipOutput writes skip information to the GITHUB_OUTPUT file.
+func writeSkipOutput(path string, skip *auth.SkipInfo) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_OUTPUT: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	lines := []string{
+		"skipped=true",
+		fmt.Sprintf("skip-reason=%s", skip.Reason),
+		"findings-count=0",
+		"critical-count=0",
+		"high-count=0",
+		"medium-count=0",
+		"low-count=0",
+	}
+
+	// Write findings as empty JSON array
+	delimiter, err := generateDelimiter()
+	if err != nil {
+		return fmt.Errorf("generate delimiter: %w", err)
+	}
+	lines = append(lines, fmt.Sprintf("findings<<%s\n[]\n%s", delimiter, delimiter))
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(f, line); err != nil {
+			return fmt.Errorf("write to GITHUB_OUTPUT: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// writeSkipSummary writes a skip summary to the GITHUB_STEP_SUMMARY file.
+func writeSkipSummary(path string, skip *auth.SkipInfo) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_STEP_SUMMARY: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Use the pre-rendered markdown comment as the summary
+	content := skip.PRComment()
+	if content == "" {
+		content = fmt.Sprintf("## bop Code Review\n\n> [!NOTE]\n> Review skipped: %s\n", skip.UserMessage())
+	}
+
+	if _, err := f.WriteString(content + "\n"); err != nil {
+		return fmt.Errorf("write to GITHUB_STEP_SUMMARY: %w", err)
+	}
+
+	return nil
+}
+
+// postSkipComment posts a PR comment explaining why the review was skipped.
+// Uses the gh CLI which is available in GitHub Actions runners.
+func postSkipComment(ghCtx *gitHubContext, skip *auth.SkipInfo) error {
+	comment := skip.PRComment()
+	if comment == "" {
+		return nil // No comment to post
+	}
+
+	// Use gh CLI to post the comment - it's pre-installed in GitHub Actions
+	// and already authenticated via GITHUB_TOKEN.
+	// We shell out rather than using the GitHub API directly to avoid
+	// adding a dependency on go-github.
+	ghToken := os.Getenv("GITHUB_TOKEN")
+	if ghToken == "" {
+		return errors.New("GITHUB_TOKEN not set, cannot post PR comment")
+	}
+
+	// Set GITHUB_TOKEN for gh CLI
+	if err := os.Setenv("GITHUB_TOKEN", ghToken); err != nil {
+		return fmt.Errorf("set GITHUB_TOKEN: %w", err)
+	}
+
+	// Use gh pr comment to post
+	// Format: gh pr comment <number> --body "..." --repo owner/repo
+	output, err := execCommand("gh",
+		"pr", "comment",
+		strconv.Itoa(ghCtx.PRNumber),
+		"--body", comment,
+		"--repo", ghCtx.Repository,
+	)
+	if err != nil {
+		return fmt.Errorf("gh pr comment failed: %w\nOutput: %s", err, string(output))
+	}
+
+	return nil
+}
+
+// execCommandFunc is a function type for running external commands.
+// It's a variable to allow mocking in tests.
+type execCommandFunc func(name string, args ...string) ([]byte, error)
+
+// execCommand runs an external command. Can be replaced in tests.
+var execCommand execCommandFunc = func(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	return cmd.CombinedOutput()
 }
 
 // writeSummaryFile writes a markdown summary to the GITHUB_STEP_SUMMARY file.

--- a/internal/adapter/cli/github_action_test.go
+++ b/internal/adapter/cli/github_action_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/delightfulhammers/bop/internal/auth"
 	"github.com/delightfulhammers/bop/internal/domain"
 	"github.com/delightfulhammers/bop/internal/usecase/review"
 )
@@ -710,5 +711,157 @@ func clearEnv(keys []string) {
 func setEnv(vars map[string]string) {
 	for k, v := range vars {
 		_ = os.Setenv(k, v)
+	}
+}
+
+func TestWriteSkipOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output")
+
+	skip := &auth.SkipInfo{
+		Reason:  auth.SkipReasonSoloNamespaceViolation,
+		Message: "actor testuser has solo plan but repo owner is orgname",
+		Comment: "## Code review skipped\n\nTest comment.",
+	}
+
+	err := writeSkipOutput(outputFile, skip)
+	if err != nil {
+		t.Fatalf("writeSkipOutput() error = %v", err)
+	}
+
+	output, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+	outputStr := string(output)
+
+	expectedOutputs := []string{
+		"skipped=true",
+		"skip-reason=solo_namespace_violation",
+		"findings-count=0",
+		"critical-count=0",
+		"high-count=0",
+		"medium-count=0",
+		"low-count=0",
+		"findings<<BOP_EOF_",
+		"[]",
+	}
+	for _, expected := range expectedOutputs {
+		if !contains(outputStr, expected) {
+			t.Errorf("output missing %q", expected)
+		}
+	}
+}
+
+func TestWriteSkipSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	summaryFile := filepath.Join(tmpDir, "summary")
+
+	skip := &auth.SkipInfo{
+		Reason:  auth.SkipReasonActorNotMember,
+		Message: "actor testuser is not a bop member",
+		Comment: "## Code review skipped\n\nActor @testuser is not a bop member.",
+	}
+
+	err := writeSkipSummary(summaryFile, skip)
+	if err != nil {
+		t.Fatalf("writeSkipSummary() error = %v", err)
+	}
+
+	summary, err := os.ReadFile(summaryFile)
+	if err != nil {
+		t.Fatalf("failed to read summary file: %v", err)
+	}
+	summaryStr := string(summary)
+
+	if !contains(summaryStr, "Code review skipped") {
+		t.Error("summary missing skip header")
+	}
+	if !contains(summaryStr, "@testuser") {
+		t.Error("summary missing actor")
+	}
+}
+
+func TestWriteSkipSummary_FallbackMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	summaryFile := filepath.Join(tmpDir, "summary")
+
+	// Skip with empty comment should use fallback
+	skip := &auth.SkipInfo{
+		Reason:  auth.SkipReasonNoActiveEntitlement,
+		Message: "actor testuser has no active entitlement",
+		Comment: "", // Empty - should use fallback
+	}
+
+	err := writeSkipSummary(summaryFile, skip)
+	if err != nil {
+		t.Fatalf("writeSkipSummary() error = %v", err)
+	}
+
+	summary, err := os.ReadFile(summaryFile)
+	if err != nil {
+		t.Fatalf("failed to read summary file: %v", err)
+	}
+	summaryStr := string(summary)
+
+	// Fallback message should be used
+	if !contains(summaryStr, "Review skipped") {
+		t.Error("summary should contain fallback message")
+	}
+}
+
+func TestHandleOIDCSkip(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output")
+	summaryFile := filepath.Join(tmpDir, "summary")
+
+	envVars := []string{"GITHUB_OUTPUT", "GITHUB_STEP_SUMMARY", "GITHUB_TOKEN"}
+	restore := saveAndClearEnv(t, envVars)
+	defer restore()
+	setEnv(map[string]string{
+		"GITHUB_OUTPUT":       outputFile,
+		"GITHUB_STEP_SUMMARY": summaryFile,
+		// No GITHUB_TOKEN - skip posting comment
+	})
+
+	ghCtx := &gitHubContext{
+		Owner:      "owner",
+		Repo:       "repo",
+		Repository: "owner/repo",
+		PRNumber:   123,
+	}
+
+	cfg := actionConfig{
+		PostFindings: true, // Want to post, but no token
+	}
+
+	skip := &auth.SkipInfo{
+		Reason:  auth.SkipReasonSoloNamespaceViolation,
+		Message: "actor testuser has solo plan but repo owner is orgname",
+		Comment: "## Code review skipped\n\nActor @testuser has a Solo plan.",
+	}
+
+	// handleOIDCSkip should return nil (success) even though comment posting fails
+	err := handleOIDCSkip(ghCtx, cfg, skip)
+	if err != nil {
+		t.Fatalf("handleOIDCSkip() should return nil, got error: %v", err)
+	}
+
+	// Verify output file was written
+	output, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+	if !contains(string(output), "skipped=true") {
+		t.Error("output should contain skipped=true")
+	}
+
+	// Verify summary file was written
+	summary, err := os.ReadFile(summaryFile)
+	if err != nil {
+		t.Fatalf("failed to read summary file: %v", err)
+	}
+	if !contains(string(summary), "Code review skipped") {
+		t.Error("summary should contain skip message")
 	}
 }

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -333,12 +333,33 @@ type OIDCExchangeRequest struct {
 	ProviderType string
 }
 
+// oidcExchangeResponse is an internal type for parsing the OIDC exchange response.
+// The platform returns either tokens or a skip result, both with HTTP 200.
+type oidcExchangeResponse struct {
+	// Token fields (present when not skipped)
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+
+	// Skip fields (present when skipped)
+	Skipped bool   `json:"skipped"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+	Comment string `json:"comment"`
+}
+
 // ExchangeOIDCToken exchanges a GitHub Actions OIDC token for platform credentials.
 // This is used for machine-to-machine authentication from CI/CD pipelines.
-func (c *Client) ExchangeOIDCToken(ctx context.Context, req OIDCExchangeRequest) (*TokenResponse, error) {
+//
+// Returns:
+// - (*TokenResponse, nil, nil): successful authentication with tokens
+// - (nil, *SkipInfo, nil): authorization passed but review should be skipped (e.g., solo namespace violation)
+// - (nil, nil, error): authentication or network failure
+func (c *Client) ExchangeOIDCToken(ctx context.Context, req OIDCExchangeRequest) (*TokenResponse, *SkipInfo, error) {
 	// Validate required inputs
 	if req.IDToken == "" {
-		return nil, fmt.Errorf("id_token is required")
+		return nil, nil, fmt.Errorf("id_token is required")
 	}
 
 	providerType := req.ProviderType
@@ -357,31 +378,50 @@ func (c *Client) ExchangeOIDCToken(ctx context.Context, req OIDCExchangeRequest)
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("marshal request: %w", err)
+		return nil, nil, fmt.Errorf("marshal request: %w", err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL("/auth/actions-oidc"), bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
+		return nil, nil, fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("OIDC exchange request: %w", err)
+		return nil, nil, fmt.Errorf("OIDC exchange request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
+		return nil, nil, c.parseError(resp)
 	}
 
-	var result TokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+	// Limit response body to prevent memory exhaustion
+	const maxResponseSize = 64 * 1024 // 64KB
+	limitedReader := io.LimitReader(resp.Body, maxResponseSize)
+
+	var result oidcExchangeResponse
+	if err := json.NewDecoder(limitedReader).Decode(&result); err != nil {
+		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 
-	return &result, nil
+	// Check if this is a skip response
+	if result.Skipped {
+		return nil, &SkipInfo{
+			Reason:  SkipReason(result.Reason),
+			Message: result.Message,
+			Comment: result.Comment,
+		}, nil
+	}
+
+	// Normal token response
+	return &TokenResponse{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		TokenType:    result.TokenType,
+		ExpiresIn:    result.ExpiresIn,
+	}, nil, nil
 }
 
 // ProductConfigResponse is the response from the config API.

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -42,12 +42,20 @@ func IsAvailable() bool {
 }
 
 // OIDCAuthResult contains the result of an OIDC authentication.
+// Either (StoredAuth, Entitlements) is populated for success, or Skip is populated for skipped reviews.
 type OIDCAuthResult struct {
 	// StoredAuth contains the authentication state (tokens, entitlements, etc.)
+	// Nil when Skip is set.
 	StoredAuth *StoredAuth
 
-	// Entitlements provides access to entitlement checking
+	// Entitlements provides access to entitlement checking.
+	// Nil when Skip is set.
 	Entitlements *BopEntitlements
+
+	// Skip contains information when the review should be skipped.
+	// Set when the platform returns a skip result instead of tokens.
+	// Nil when authentication succeeds with tokens.
+	Skip *SkipInfo
 }
 
 // Authenticate requests an OIDC token from GitHub Actions and exchanges it
@@ -69,13 +77,22 @@ func (g *GitHubActionsOIDC) Authenticate(ctx context.Context, tenantID string) (
 	}
 
 	// Exchange OIDC token for platform credentials
-	tokenResp, err := g.client.ExchangeOIDCToken(ctx, OIDCExchangeRequest{
+	tokenResp, skipInfo, err := g.client.ExchangeOIDCToken(ctx, OIDCExchangeRequest{
 		TenantID:     tenantID,
 		IDToken:      idToken,
 		ProviderType: "github",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("exchange OIDC token: %w", err)
+	}
+
+	// Handle skip response - the platform returns this when auth succeeds but
+	// the actor doesn't have the right entitlements for this operation.
+	// Return it as a successful result with Skip set, not an error.
+	if skipInfo != nil {
+		return &OIDCAuthResult{
+			Skip: skipInfo,
+		}, nil
 	}
 
 	// Get user info to populate StoredAuth

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -435,7 +435,7 @@ func TestAPIError_ErrorsAs(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, exchangeErr := client.ExchangeOIDCToken(context.Background(), OIDCExchangeRequest{
+			_, _, exchangeErr := client.ExchangeOIDCToken(context.Background(), OIDCExchangeRequest{
 				IDToken:      "test-token",
 				TenantID:     "tenant-123",
 				ProviderType: "github",
@@ -516,5 +516,172 @@ func TestIsTenantNotConfigured(t *testing.T) {
 				t.Errorf("IsTenantNotConfigured() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExchangeOIDCToken_SkipResponse(t *testing.T) {
+	// Test that ExchangeOIDCToken correctly detects and returns skip responses.
+	// The platform returns HTTP 200 with {"skipped": true, ...} instead of tokens.
+	tests := []struct {
+		name       string
+		response   string
+		wantReason SkipReason
+		wantMsg    string
+	}{
+		{
+			name: "actor_not_member skip",
+			response: `{
+				"skipped": true,
+				"reason": "actor_not_member",
+				"message": "actor testuser is not a bop member",
+				"comment": "## Code review skipped\n\nActor @testuser is not a bop member."
+			}`,
+			wantReason: SkipReasonActorNotMember,
+			wantMsg:    "actor testuser is not a bop member",
+		},
+		{
+			name: "no_active_entitlement skip",
+			response: `{
+				"skipped": true,
+				"reason": "no_active_entitlement",
+				"message": "actor testuser has no active entitlement",
+				"comment": "## Code review skipped\n\nActor @testuser does not have an active subscription."
+			}`,
+			wantReason: SkipReasonNoActiveEntitlement,
+			wantMsg:    "actor testuser has no active entitlement",
+		},
+		{
+			name: "solo_namespace_violation skip",
+			response: `{
+				"skipped": true,
+				"reason": "solo_namespace_violation",
+				"message": "actor testuser has solo plan but repo owner is orgname",
+				"comment": "## Code review skipped\n\nActor @testuser has a Solo plan."
+			}`,
+			wantReason: SkipReasonSoloNamespaceViolation,
+			wantMsg:    "actor testuser has solo plan but repo owner is orgname",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client, err := NewClient(ClientConfig{BaseURL: server.URL, ProductID: "bop"})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result, skipInfo, err := client.ExchangeOIDCToken(context.Background(), OIDCExchangeRequest{
+				IDToken:      "test-token",
+				ProviderType: "github",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != nil {
+				t.Errorf("expected nil TokenResponse for skip, got %+v", result)
+			}
+			if skipInfo == nil {
+				t.Fatal("expected non-nil SkipInfo")
+			}
+			if skipInfo.Reason != tt.wantReason {
+				t.Errorf("Reason = %q, want %q", skipInfo.Reason, tt.wantReason)
+			}
+			if skipInfo.Message != tt.wantMsg {
+				t.Errorf("Message = %q, want %q", skipInfo.Message, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestExchangeOIDCToken_TokenResponse(t *testing.T) {
+	// Verify that normal token responses still work after skip handling is added.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "test-access-token",
+			"refresh_token": "test-refresh-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{BaseURL: server.URL, ProductID: "bop"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, skipInfo, err := client.ExchangeOIDCToken(context.Background(), OIDCExchangeRequest{
+		IDToken:      "test-token",
+		ProviderType: "github",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if skipInfo != nil {
+		t.Errorf("expected nil SkipInfo for token response, got %+v", skipInfo)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil TokenResponse")
+	}
+	if result.AccessToken != "test-access-token" {
+		t.Errorf("AccessToken = %q, want %q", result.AccessToken, "test-access-token")
+	}
+}
+
+func TestGitHubActionsOIDC_Authenticate_Skip(t *testing.T) {
+	// Test that the OIDC Authenticate flow correctly handles skip responses.
+	expectedToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test"
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": expectedToken})
+	}))
+	defer oidcServer.Close()
+
+	platformServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a skip response instead of tokens
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"skipped": true,
+			"reason":  "solo_namespace_violation",
+			"message": "actor testuser has solo plan but repo owner is orgname",
+			"comment": "## Code review skipped\n\nActor @testuser has a Solo plan.",
+		})
+	}))
+	defer platformServer.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", oidcServer.URL+"?param=value")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-request-token")
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:   platformServer.URL,
+		ProductID: "bop",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oidc := NewGitHubActionsOIDC(client, "https://api.example.com")
+	result, authErr := oidc.Authenticate(context.Background(), "")
+	if authErr != nil {
+		t.Fatalf("Authenticate() error: %v", authErr)
+	}
+
+	// Skip should be returned without error
+	if result.StoredAuth != nil {
+		t.Errorf("expected nil StoredAuth for skip, got %+v", result.StoredAuth)
+	}
+	if result.Skip == nil {
+		t.Fatal("expected non-nil Skip")
+	}
+	if result.Skip.Reason != SkipReasonSoloNamespaceViolation {
+		t.Errorf("Skip.Reason = %q, want %q", result.Skip.Reason, SkipReasonSoloNamespaceViolation)
 	}
 }

--- a/internal/auth/skip.go
+++ b/internal/auth/skip.go
@@ -1,0 +1,72 @@
+// Package auth provides platform authentication for bop CLI and MCP server.
+package auth
+
+// SkipReason represents the reason why a code review was skipped.
+// These values match the platform's domain.SkipReason constants.
+type SkipReason string
+
+// Skip reason constants matching platform/internal/auth/domain/skip.go.
+const (
+	// SkipReasonActorNotMember indicates the GitHub actor is not a bop member.
+	SkipReasonActorNotMember SkipReason = "actor_not_member"
+
+	// SkipReasonNoActiveEntitlement indicates the actor has no active subscription.
+	SkipReasonNoActiveEntitlement SkipReason = "no_active_entitlement"
+
+	// SkipReasonSoloNamespaceViolation indicates a solo user tried to review a non-personal repo.
+	SkipReasonSoloNamespaceViolation SkipReason = "solo_namespace_violation"
+)
+
+// validSkipReasons contains all valid skip reason values.
+var validSkipReasons = []SkipReason{
+	SkipReasonActorNotMember,
+	SkipReasonNoActiveEntitlement,
+	SkipReasonSoloNamespaceViolation,
+}
+
+// IsValid checks if the skip reason is valid.
+func (r SkipReason) IsValid() bool {
+	for _, valid := range validSkipReasons {
+		if r == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// String returns the string representation of the skip reason.
+func (r SkipReason) String() string {
+	return string(r)
+}
+
+// SkipInfo contains information about why a code review was skipped.
+// This is returned by the platform when authorization passes but the actor
+// doesn't have the right entitlements for the requested operation.
+type SkipInfo struct {
+	// Reason is the skip reason code.
+	Reason SkipReason
+
+	// Message is a human-readable message for logging.
+	Message string
+
+	// Comment is the pre-rendered markdown for a PR comment.
+	Comment string
+}
+
+// UserMessage returns the human-readable message for logging.
+// Returns empty string if the SkipInfo is nil.
+func (s *SkipInfo) UserMessage() string {
+	if s == nil {
+		return ""
+	}
+	return s.Message
+}
+
+// PRComment returns the markdown content for posting as a PR comment.
+// Returns empty string if the SkipInfo is nil.
+func (s *SkipInfo) PRComment() string {
+	if s == nil {
+		return ""
+	}
+	return s.Comment
+}

--- a/internal/auth/skip_test.go
+++ b/internal/auth/skip_test.go
@@ -1,0 +1,147 @@
+package auth
+
+import "testing"
+
+func TestSkipReason_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason SkipReason
+		want   bool
+	}{
+		{
+			name:   "actor_not_member is valid",
+			reason: SkipReasonActorNotMember,
+			want:   true,
+		},
+		{
+			name:   "no_active_entitlement is valid",
+			reason: SkipReasonNoActiveEntitlement,
+			want:   true,
+		},
+		{
+			name:   "solo_namespace_violation is valid",
+			reason: SkipReasonSoloNamespaceViolation,
+			want:   true,
+		},
+		{
+			name:   "empty string is invalid",
+			reason: SkipReason(""),
+			want:   false,
+		},
+		{
+			name:   "unknown reason is invalid",
+			reason: SkipReason("unknown_reason"),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reason.IsValid(); got != tt.want {
+				t.Errorf("SkipReason(%q).IsValid() = %v, want %v", tt.reason, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipInfo_UserMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		skip *SkipInfo
+		want string
+	}{
+		{
+			name: "actor not member",
+			skip: &SkipInfo{
+				Reason:  SkipReasonActorNotMember,
+				Message: "actor testuser is not a bop member",
+			},
+			want: "actor testuser is not a bop member",
+		},
+		{
+			name: "no active entitlement",
+			skip: &SkipInfo{
+				Reason:  SkipReasonNoActiveEntitlement,
+				Message: "actor testuser has no active entitlement",
+			},
+			want: "actor testuser has no active entitlement",
+		},
+		{
+			name: "solo namespace violation",
+			skip: &SkipInfo{
+				Reason:  SkipReasonSoloNamespaceViolation,
+				Message: "actor testuser has solo plan but repo owner is orgname",
+			},
+			want: "actor testuser has solo plan but repo owner is orgname",
+		},
+		{
+			name: "nil skip info",
+			skip: nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.skip.UserMessage(); got != tt.want {
+				t.Errorf("SkipInfo.UserMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipInfo_CommentMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		skip     *SkipInfo
+		contains []string // strings that should be in the comment
+	}{
+		{
+			name: "actor not member has proper markdown",
+			skip: &SkipInfo{
+				Reason:  SkipReasonActorNotMember,
+				Comment: "## Code review skipped\n\nActor @testuser is not a bop member.",
+			},
+			contains: []string{"Code review skipped", "@testuser", "not a bop member"},
+		},
+		{
+			name: "solo namespace violation has upgrade link",
+			skip: &SkipInfo{
+				Reason:  SkipReasonSoloNamespaceViolation,
+				Comment: "## Code review skipped\n\nActor @testuser has a Solo plan.\n\n[Upgrade to Pro](https://delightfulhammers.com/bop/upgrade)",
+			},
+			contains: []string{"Code review skipped", "Solo plan", "Upgrade to Pro"},
+		},
+		{
+			name: "nil skip info returns empty",
+			skip: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comment := tt.skip.PRComment()
+			if tt.skip == nil {
+				if comment != "" {
+					t.Errorf("nil SkipInfo.PRComment() = %q, want empty", comment)
+				}
+				return
+			}
+			for _, substr := range tt.contains {
+				if !contains(comment, substr) {
+					t.Errorf("SkipInfo.PRComment() = %q, missing expected substring %q", comment, substr)
+				}
+			}
+		})
+	}
+}
+
+// contains is a simple helper since strings.Contains is what we need
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Implement skip response handling in the bop client for the actor-based authorization model
- When the platform determines an actor doesn't have the right entitlements, it returns a skip result instead of tokens
- The client handles this gracefully by writing outputs/summary and posting a PR comment

## Changes

### New Files
- `internal/auth/skip.go` - SkipReason and SkipInfo types
- `internal/auth/skip_test.go` - Tests for skip types

### Modified Files
- `internal/auth/client.go` - ExchangeOIDCToken now returns `(*TokenResponse, *SkipInfo, error)`
- `internal/auth/oidc.go` - OIDCAuthResult includes Skip field, Authenticate handles skip
- `internal/auth/oidc_test.go` - Tests for skip response handling
- `internal/adapter/cli/github_action.go` - handleOIDCSkip, writeSkipOutput, writeSkipSummary, postSkipComment
- `internal/adapter/cli/github_action_test.go` - Tests for skip handling in GitHub Action

### Skip Reasons Supported
- `actor_not_member`: GitHub actor is not a bop member
- `no_active_entitlement`: Actor has no active subscription  
- `solo_namespace_violation`: Solo plan user on non-personal repo

## Test plan

- [x] All existing tests pass
- [x] New skip type tests pass
- [x] New OIDC skip handling tests pass
- [x] New GitHub Action skip handling tests pass
- [x] Race detector passes
- [x] Lint passes (0 issues)
- [x] Build succeeds